### PR TITLE
LIX-293 # Consolidate workspace media URL resolution and token refresh into shared util

### DIFF
--- a/services/api/src/server.ts
+++ b/services/api/src/server.ts
@@ -259,7 +259,7 @@ app.use(cookieParser())
 
 // Unified file upload/download route — accepts any media kind, sniffs the bytes,
 // transcodes to a model-safe canonical, and serves originals/canonicals/posters
-// (Range-capable for audio/video). Replaces the retired /api/images + /api/videos.
+// with Range support for seekable media.
 app.use('/api/files', fileRoutes)
 
 // Workspace export routes

--- a/services/web-ui/src/components/contextPreview/contextPreview.test.ts
+++ b/services/web-ui/src/components/contextPreview/contextPreview.test.ts
@@ -7,19 +7,26 @@ function createMockEnvironment(overrides: {
     threads?: { threadId: string; title?: string; content?: string | object }[]
     authToken?: string
     apiBaseUrl?: string
-} = {}): ContextPreviewEnvironment {
+} = {}): ContextPreviewEnvironment & {
+    getDocuments: ReturnType<typeof vi.fn>
+    getThreads: ReturnType<typeof vi.fn>
+    getAuthToken: ReturnType<typeof vi.fn>
+} {
     const {
         documents = [],
         threads = [],
         authToken = 'token-123',
         apiBaseUrl = 'https://api.example.com',
     } = overrides
+    const getDocuments = vi.fn(() => documents)
+    const getThreads = vi.fn(() => threads)
+    const getAuthToken = vi.fn(async () => authToken)
 
     return {
-        getDocuments: () => documents,
-        getThreads: () => threads,
+        getDocuments,
+        getThreads,
         getApiBaseUrl: () => apiBaseUrl,
-        getAuthToken: vi.fn(async () => authToken),
+        getAuthToken,
     }
 }
 
@@ -119,6 +126,41 @@ describe('context preview labels', () => {
             ),
         ).toBe('unknown')
     })
+
+    it('trims document titles before using them as the accessible label', () => {
+        const env = createMockEnvironment({
+            documents: [{ documentId: 'document-node', title: '  Project Notes  ' }],
+        })
+
+        expect(getContextPreviewAccessibleLabel(createDocumentNode(), env)).toBe('Project Notes')
+    })
+
+    it('falls back to extracted document content when the descriptor summary is blank', async () => {
+        const env = createMockEnvironment({
+            documents: [
+                {
+                    documentId: 'document-node',
+                    title: 'Draft Note',
+                    content: createTextDoc('Draft content should win over blank summary'),
+                },
+            ],
+        })
+        const { dom } = createContextPreviewTile({
+            node: createDocumentNode({
+                descriptor: { status: 'ready', summary: '   ' },
+            }),
+            environment: env,
+        })
+        document.body.appendChild(dom)
+
+        const trigger = dom.querySelector('.help-tooltip-trigger') as HTMLElement
+        trigger.dispatchEvent(new PointerEvent('pointerenter', { bubbles: true }))
+        await waitForMicrotasks()
+
+        const tooltipContent = document.body.querySelector('.help-tooltip-content') as HTMLElement
+        expect(tooltipContent.querySelector('.workspace-ai-chat-panel-context-preview-document-text')?.textContent)
+            .toBe('Draft content should win over blank summary')
+    })
 })
 
 describe('createContextPreviewTile', () => {
@@ -172,6 +214,53 @@ describe('createContextPreviewTile', () => {
         const imageEl = document.body.querySelector('.help-tooltip-content .workspace-ai-chat-panel-context-preview-image') as HTMLImageElement
         expect(imageEl.src).toBe('data:image/png;base64,QUJD')
         expect(env.getAuthToken).not.toHaveBeenCalled()
+    })
+
+    it('does not apply authenticated media URLs after the tile is detached before token resolution', async () => {
+        const env = createMockEnvironment()
+        let resolveAuth: ((value: string | undefined) => void) | null = null
+        env.getAuthToken = vi.fn(() => new Promise((resolve) => {
+            resolveAuth = resolve
+        }))
+
+        const { dom } = createContextPreviewTile({
+            node: createImageNode({ src: '/api/files/images/raw.png' }),
+            environment: env,
+        })
+        document.body.appendChild(dom)
+
+        const imageEl = dom.querySelector('.workspace-ai-chat-panel-context-preview-image') as HTMLImageElement
+        expect(imageEl).not.toBeNull()
+
+        dom.remove()
+        resolveAuth?.('auth-token')
+        await waitForNextTick()
+
+        expect(imageEl.src).toContain('/api/files/images/raw.png')
+        expect(imageEl.src).not.toContain('token=auth-token')
+    })
+
+    it('uses the base popover class when image/video metadata is missing', async () => {
+        const env = createMockEnvironment()
+        const { dom, destroy } = createContextPreviewTile({
+            node: createImageNode(),
+            environment: env,
+        })
+        document.body.appendChild(dom)
+
+        const trigger = dom.querySelector('.help-tooltip-trigger') as HTMLElement
+        trigger.dispatchEvent(new PointerEvent('pointerenter', { bubbles: true }))
+        await waitForMicrotasks()
+
+        const tooltipContent = document.body.querySelector('.help-tooltip-content') as HTMLElement
+        expect(tooltipContent.className).toContain('workspace-ai-chat-panel-context-preview-popover')
+        expect(tooltipContent.className).not.toContain('workspace-ai-chat-panel-context-preview-popover-portrait')
+        expect(tooltipContent.className).not.toContain('workspace-ai-chat-panel-context-preview-popover-landscape')
+
+        const popoverBody = tooltipContent.querySelector('.workspace-ai-chat-panel-context-preview-popover-body') as HTMLElement
+        expect(popoverBody.className).toContain('workspace-ai-chat-panel-context-preview-popover-body-landscape')
+
+        destroy()
     })
 
     it('applies preferred inline popover placement to generated class names', () => {

--- a/services/web-ui/src/components/contextPreview/contextPreview.ts
+++ b/services/web-ui/src/components/contextPreview/contextPreview.ts
@@ -8,6 +8,10 @@ import { createHelpTooltip, type HelpTooltipInstance } from '$src/components/hel
 import { extractContentFromProseMirror } from '$src/services/ai-chat-thread-service.ts'
 import { documentIcon, videoPlayGlyphIcon } from '$src/svgIcons/index.ts'
 import { html } from '$src/utils/domTemplates.ts'
+import {
+    resolveAuthenticatedMediaUrl,
+    resolveMediaUrl,
+} from '$src/utils/workspaceFileUrls.ts'
 
 export type ContextPreviewDocumentSource = {
     documentId: string
@@ -118,43 +122,19 @@ export function getContextPreviewAccessibleLabel(node: CanvasNode, environment: 
 }
 
 function buildContextPreviewInitialMediaSrc(mediaUrl: string): string {
-    if (!mediaUrl) return TRANSPARENT_PIXEL_SRC
-    if (mediaUrl.startsWith('data:') || mediaUrl.startsWith('blob:')) return mediaUrl
-    if (mediaUrl.startsWith('/api/') || mediaUrl.startsWith('http')) return mediaUrl
-    return `data:image/png;base64,${mediaUrl}`
-}
-
-function setContextPreviewMediaTokenParam(mediaUrl: string, token: string): string {
-    if (!token) return mediaUrl
-    const isAbsoluteUrl = /^[a-z][a-z0-9+.-]*:\/\//i.test(mediaUrl)
-    try {
-        const url = isAbsoluteUrl ? new URL(mediaUrl) : new URL(mediaUrl, window.location.origin)
-        url.searchParams.set('token', token)
-        if (isAbsoluteUrl) return url.toString()
-        return `${url.pathname}${url.search}${url.hash}`
-    } catch {
-        const separator = mediaUrl.includes('?') ? '&' : '?'
-        return `${mediaUrl}${separator}token=${encodeURIComponent(token)}`
-    }
+    return resolveMediaUrl(mediaUrl, {
+        base64MimeType: 'image/png',
+        emptyFallback: TRANSPARENT_PIXEL_SRC,
+    })
 }
 
 async function buildContextPreviewAuthenticatedMediaSrc(mediaUrl: string, environment: ContextPreviewEnvironment): Promise<string> {
-    if (!mediaUrl) return TRANSPARENT_PIXEL_SRC
-    if (mediaUrl.startsWith('data:') || mediaUrl.startsWith('blob:')) return mediaUrl
-    if (mediaUrl.startsWith('/api/')) {
-        const token = await environment.getAuthToken()
-        const apiBaseUrl = environment.getApiBaseUrl().replace(/\/$/, '')
-        const sourceUrl = apiBaseUrl ? `${apiBaseUrl}${mediaUrl}` : mediaUrl
-        return setContextPreviewMediaTokenParam(sourceUrl, token)
-    }
-    if (mediaUrl.startsWith('http')) {
-        if (mediaUrl.includes('/api/files/')) {
-            const token = await environment.getAuthToken()
-            return setContextPreviewMediaTokenParam(mediaUrl, token)
-        }
-        return mediaUrl
-    }
-    return `data:image/png;base64,${mediaUrl}`
+    return resolveAuthenticatedMediaUrl(mediaUrl, {
+        apiBaseUrl: environment.getApiBaseUrl(),
+        base64MimeType: 'image/png',
+        emptyFallback: TRANSPARENT_PIXEL_SRC,
+        getAuthToken: environment.getAuthToken,
+    })
 }
 
 function hydrateContextPreviewMedia(

--- a/services/web-ui/src/components/navigationSidePanel/navigationSidePanel.test.ts
+++ b/services/web-ui/src/components/navigationSidePanel/navigationSidePanel.test.ts
@@ -1,0 +1,695 @@
+'use strict'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { LoadingStatus, type WorkspaceMeta } from '@lixpi/constants'
+
+// =============================================================================
+// MOCKED COLLABORATORS
+// =============================================================================
+//
+// NavigationSidePanel drives real navigation, workspace CRUD, auth, and file
+// import/export side effects. Those collaborators are mocked so tests assert
+// on *what NavigationSidePanel asked them to do*, not on their own internals
+// (which have their own test suites). The nanostores-backed panel/workspace
+// stores below are exercised for real — they are cheap, synchronous, and
+// resettable, so mocking them would just hide real integration bugs.
+
+const mocks = vi.hoisted(() => ({
+    navigateTo: vi.fn(),
+    createWorkspace: vi.fn().mockResolvedValue(undefined),
+    deleteWorkspace: vi.fn().mockResolvedValue(undefined),
+    getWorkspace: vi.fn().mockResolvedValue(undefined),
+    getTokenSilently: vi.fn(),
+    getWorkspaceDocuments: vi.fn().mockResolvedValue(undefined),
+    getWorkspaceAiChatThreads: vi.fn().mockResolvedValue(undefined),
+    dropdownInstances: [] as Array<{ dom: HTMLDivElement; destroy: () => void; config: any }>,
+}))
+
+vi.mock('$src/services/router-service.ts', () => ({
+    default: { navigateTo: mocks.navigateTo },
+}))
+
+vi.mock('$src/services/workspace-service.ts', () => ({
+    default: vi.fn().mockImplementation(function (this: Record<string, unknown>) {
+        this.createWorkspace = mocks.createWorkspace
+        this.deleteWorkspace = mocks.deleteWorkspace
+        this.getWorkspace = mocks.getWorkspace
+    }),
+}))
+
+vi.mock('$src/services/auth-service.ts', () => ({
+    default: { getTokenSilently: mocks.getTokenSilently },
+}))
+
+// The dropdown is a fully separate, already-tested component. NavigationSidePanel's
+// own responsibility is *what it configures the dropdown with* (options, onSelect
+// routing) — that's what these tests exercise, via the captured config.
+vi.mock('$src/components/dropdown/index.ts', () => ({
+    createPureDropdown: vi.fn((config: any) => {
+        const dom = document.createElement('div')
+        dom.className = 'mock-dropdown'
+        const instance = { dom, destroy: vi.fn(), config }
+        mocks.dropdownInstances.push(instance)
+        return instance
+    }),
+}))
+
+import { createNavigationSidePanel, type NavigationSidePanelInstance } from '$src/components/navigationSidePanel/navigationSidePanel.ts'
+import { workspacesStore } from '$src/stores/workspacesStore.ts'
+import { workspaceStore } from '$src/stores/workspaceStore.ts'
+import { routerStore } from '$src/stores/routerStore.ts'
+import { servicesStore } from '$src/stores/servicesStore.ts'
+import { authStore } from '$src/stores/authStore.ts'
+import { navigationSidePanelStore, userInfoPanelStore } from '$src/stores/navigationSidePanelStore.ts'
+import { settings } from '$src/settings.ts'
+
+function makeWorkspace(overrides: Partial<WorkspaceMeta> & { tags?: string[] } = {}): WorkspaceMeta {
+    return {
+        workspaceId: 'workspace-1',
+        name: 'Workspace One',
+        createdAt: 0,
+        updatedAt: 0,
+        ...overrides,
+    } as WorkspaceMeta
+}
+
+function setCurrentWorkspaceId(workspaceId: string | undefined): void {
+    routerStore.setDataValues({
+        currentRoute: {
+            ...routerStore.getData('currentRoute'),
+            routeParams: workspaceId ? { workspaceId } : {},
+        },
+    })
+}
+
+function mount(): { paneEl: HTMLDivElement; instance: NavigationSidePanelInstance } {
+    const paneEl = document.createElement('div')
+    document.body.appendChild(paneEl)
+    const instance = createNavigationSidePanel({ paneEl })
+    return { paneEl, instance }
+}
+
+// Svelte stores replay their current value to a listener the moment it
+// subscribes, so the constructor's `renderWorkspaceList()` call is immediately
+// followed by one more synchronous re-render from `workspacesStore.subscribe`.
+// The live dropdown for a workspace is therefore the *last* one captured, not
+// the first — the first is already torn down by the time mount() returns.
+function liveDropdownFor(workspaceId: string) {
+    const matches = mocks.dropdownInstances.filter((entry) => entry.config.id === `navigation-side-panel-workspace-menu-${workspaceId}`)
+    const instance = matches[matches.length - 1]
+    if (!instance) throw new Error(`no dropdown captured for ${workspaceId}`)
+    return instance
+}
+
+function dropdownConfigFor(workspaceId: string) {
+    return liveDropdownFor(workspaceId).config
+}
+
+let consoleErrorSpy: ReturnType<typeof vi.spyOn> | null = null
+
+beforeEach(() => {
+    mocks.dropdownInstances.length = 0
+    mocks.navigateTo.mockClear()
+    mocks.createWorkspace.mockClear()
+    mocks.deleteWorkspace.mockClear()
+    mocks.getWorkspace.mockClear()
+    mocks.getTokenSilently.mockReset()
+    mocks.getWorkspaceDocuments.mockClear()
+    mocks.getWorkspaceAiChatThreads.mockClear()
+
+    workspacesStore.resetStore()
+    workspaceStore.resetStore()
+    routerStore.resetStore()
+    servicesStore.resetStore()
+    authStore.resetStore()
+    navigationSidePanelStore.resetStore()
+    userInfoPanelStore.set(false)
+
+    servicesStore.setDataValues({
+        documentService: { getWorkspaceDocuments: mocks.getWorkspaceDocuments },
+        aiChatThreadService: { getWorkspaceAiChatThreads: mocks.getWorkspaceAiChatThreads },
+    })
+
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+})
+
+afterEach(() => {
+    document.body.innerHTML = ''
+    consoleErrorSpy?.mockRestore()
+    consoleErrorSpy = null
+})
+
+// =============================================================================
+// MOUNTING AND STRUCTURE
+// =============================================================================
+
+describe('NavigationSidePanel — mounting', () => {
+    it('mounts the panel, its side-panel surfaces, and the new-workspace button into the host pane', () => {
+        const { paneEl, instance } = mount()
+
+        expect(paneEl.querySelector('.navigation-side-panel')).not.toBeNull()
+        expect(paneEl.querySelector('.navigation-side-panel-header')).not.toBeNull()
+        expect(paneEl.querySelector('.navigation-side-panel-list')).not.toBeNull()
+        expect(paneEl.querySelector('.navigation-side-panel-footer')).not.toBeNull()
+        expect(paneEl.querySelector('.navigation-side-panel-new-workspace-button')).not.toBeNull()
+        expect(paneEl.querySelector('.navigation-side-panel-resize-handle')).not.toBeNull()
+        expect(paneEl.querySelector('.navigation-side-panel-toggle')).not.toBeNull()
+        expect(paneEl.querySelector('.side-panel-overlay')).not.toBeNull()
+        expect(paneEl.querySelector('.side-panel-backdrop')).not.toBeNull()
+
+        instance.destroy()
+    })
+
+    it('reflects the resolved panel width onto both the pane and panel elements as CSS custom properties', () => {
+        const { paneEl, instance } = mount()
+
+        // Never resized -> falls back to settings.navigationSidePanel.defaultDimensions.width (280).
+        expect(paneEl.style.getPropertyValue('--workspace-navigation-side-panel-width')).toBe('280px')
+        expect(paneEl.style.getPropertyValue('--side-panel-backdrop-width')).toBe('280px')
+        const panelEl = paneEl.querySelector<HTMLDivElement>('.navigation-side-panel')
+        expect(panelEl?.style.getPropertyValue('--side-panel-backdrop-width')).toBe('280px')
+
+        instance.destroy()
+    })
+
+    it('applies visual style tokens from app settings to the host pane', () => {
+        const { paneEl, instance } = mount()
+
+        expect(paneEl.style.getPropertyValue('--side-panel-backdrop-fill')).toBe(settings.navigationSidePanel.styles.backdropFill)
+        expect(paneEl.style.getPropertyValue('--side-panel-backdrop-fill-opaque')).toBe(settings.navigationSidePanel.styles.backdropFillOpaque)
+        expect(paneEl.style.getPropertyValue('--side-panel-toggle-color')).toBe(settings.navigationSidePanel.styles.toggleColor)
+        expect(paneEl.style.getPropertyValue('--side-panel-toggle-hover-color')).toBe(settings.navigationSidePanel.styles.toggleHoverColor)
+
+        instance.destroy()
+    })
+
+    it('starts open by default and renders the panel at rest, matching the store default', () => {
+        const { paneEl, instance } = mount()
+
+        expect(navigationSidePanelStore.getData('isOpen')).toBe(true)
+        const panelEl = paneEl.querySelector<HTMLDivElement>('.navigation-side-panel')
+        expect(panelEl?.style.transform).not.toBe('translate3d(-100%, 0, 0)')
+
+        instance.destroy()
+    })
+
+    it('mounts closed at rest when the persisted store state says closed', () => {
+        navigationSidePanelStore.setValues({ isOpen: false })
+        const { paneEl, instance } = mount()
+
+        const panelEl = paneEl.querySelector<HTMLDivElement>('.navigation-side-panel')
+        expect(panelEl?.style.transform).toBe('translate3d(-100%, 0, 0)')
+        const backdropEl = paneEl.querySelector<HTMLDivElement>('.side-panel-backdrop')
+        expect(backdropEl?.style.transform).toBe('translate3d(-100%, 0, 0)')
+
+        instance.destroy()
+    })
+})
+
+// =============================================================================
+// AVATAR RENDERING
+// =============================================================================
+
+describe('NavigationSidePanel — avatar', () => {
+    it('renders an initial letter fallback when there is no signed-in user', () => {
+        const { paneEl, instance } = mount()
+
+        const avatar = paneEl.querySelector('.navigation-side-panel-avatar')
+        expect(avatar?.querySelector('img')).toBeNull()
+        expect(avatar?.querySelector('.navigation-side-panel-avatar-initial')?.textContent).toBe('U')
+
+        instance.destroy()
+    })
+
+    it('renders an <img> from the user picture when available', () => {
+        const { paneEl, instance } = mount()
+        authStore.setDataValues({ user: { userId: 'u1', name: 'Ada Lovelace', email: 'a@example.com', picture: 'https://example.com/a.png', given_name: 'Ada' } as any })
+
+        const avatar = paneEl.querySelector('.navigation-side-panel-avatar')
+        const img = avatar?.querySelector('img')
+        expect(img?.getAttribute('src')).toBe('https://example.com/a.png')
+        expect(img?.getAttribute('alt')).toBe('Ada')
+
+        instance.destroy()
+    })
+
+    it('falls back to the given_name initial when there is no picture', () => {
+        const { paneEl, instance } = mount()
+        authStore.setDataValues({ user: { userId: 'u1', name: 'Grace Hopper', email: 'g@example.com', given_name: 'Grace' } as any })
+
+        const avatar = paneEl.querySelector('.navigation-side-panel-avatar')
+        expect(avatar?.querySelector('.navigation-side-panel-avatar-initial')?.textContent).toBe('G')
+
+        instance.destroy()
+    })
+
+    it('re-renders the avatar reactively when the auth store changes after mount', () => {
+        const { paneEl, instance } = mount()
+        expect(paneEl.querySelector('.navigation-side-panel-avatar-initial')?.textContent).toBe('U')
+
+        authStore.setDataValues({ user: { userId: 'u1', name: 'Zoe', email: 'z@example.com', given_name: 'Zoe' } as any })
+        expect(paneEl.querySelector('.navigation-side-panel-avatar-initial')?.textContent).toBe('Z')
+
+        instance.destroy()
+    })
+
+    it('opens the account/user-info panel when the avatar is clicked', () => {
+        const { paneEl, instance } = mount()
+        expect(userInfoPanelStore.get()).toBe(false)
+
+        paneEl.querySelector<HTMLElement>('.navigation-side-panel-avatar')?.click()
+
+        expect(userInfoPanelStore.get()).toBe(true)
+
+        instance.destroy()
+    })
+})
+
+// =============================================================================
+// WORKSPACE LIST RENDERING
+// =============================================================================
+
+describe('NavigationSidePanel — workspace list', () => {
+    it('renders one row per workspace with its name and tags', () => {
+        workspacesStore.setWorkspaces([
+            makeWorkspace({ workspaceId: 'ws-1', name: 'Alpha', tags: ['a', 'b'] }),
+            makeWorkspace({ workspaceId: 'ws-2', name: 'Beta' }),
+        ])
+        const { paneEl, instance } = mount()
+
+        const rows = paneEl.querySelectorAll('.navigation-side-panel-row')
+        expect(rows.length).toBe(2)
+        expect(rows[0].querySelector('.navigation-side-panel-row-title')?.textContent).toBe('Alpha')
+        expect(Array.from(rows[0].querySelectorAll('.navigation-side-panel-row-tag')).map((el) => el.textContent)).toEqual(['a', 'b'])
+        expect(rows[1].querySelector('.navigation-side-panel-row-tags')).toBeNull()
+
+        instance.destroy()
+    })
+
+    it('marks the row for the workspace that matches the current route as active', () => {
+        workspacesStore.setWorkspaces([
+            makeWorkspace({ workspaceId: 'ws-1', name: 'Alpha' }),
+            makeWorkspace({ workspaceId: 'ws-2', name: 'Beta' }),
+        ])
+        setCurrentWorkspaceId('ws-2')
+        const { paneEl, instance } = mount()
+
+        const rows = paneEl.querySelectorAll('.navigation-side-panel-row')
+        expect(rows[0].classList.contains('navigation-side-panel-row-active')).toBe(false)
+        expect(rows[1].classList.contains('navigation-side-panel-row-active')).toBe(true)
+
+        instance.destroy()
+    })
+
+    it('re-renders the list when the workspaces store changes after mount', () => {
+        const { paneEl, instance } = mount()
+        expect(paneEl.querySelectorAll('.navigation-side-panel-row').length).toBe(0)
+
+        workspacesStore.setWorkspaces([makeWorkspace({ workspaceId: 'ws-1', name: 'Alpha' })])
+
+        expect(paneEl.querySelectorAll('.navigation-side-panel-row').length).toBe(1)
+
+        instance.destroy()
+    })
+
+    it('re-renders the list (updating the active row) when the router store changes after mount', () => {
+        workspacesStore.setWorkspaces([makeWorkspace({ workspaceId: 'ws-1', name: 'Alpha' })])
+        const { paneEl, instance } = mount()
+        expect(paneEl.querySelector('.navigation-side-panel-row')?.classList.contains('navigation-side-panel-row-active')).toBe(false)
+
+        setCurrentWorkspaceId('ws-1')
+
+        expect(paneEl.querySelector('.navigation-side-panel-row')?.classList.contains('navigation-side-panel-row-active')).toBe(true)
+
+        instance.destroy()
+    })
+
+    it('destroys every previous row dropdown before rendering the next list snapshot', () => {
+        workspacesStore.setWorkspaces([makeWorkspace({ workspaceId: 'ws-1', name: 'Alpha' })])
+        const { instance } = mount()
+        const liveDropdown = liveDropdownFor('ws-1')
+        expect(liveDropdown.destroy).not.toHaveBeenCalled()
+
+        workspacesStore.setWorkspaces([makeWorkspace({ workspaceId: 'ws-1', name: 'Alpha (renamed)' })])
+
+        expect(liveDropdown.destroy).toHaveBeenCalledTimes(1)
+        expect(liveDropdownFor('ws-1')).not.toBe(liveDropdown)
+
+        instance.destroy()
+    })
+
+    it('stops row-menu clicks from bubbling into the row navigation handler', () => {
+        workspacesStore.setWorkspaces([makeWorkspace({ workspaceId: 'ws-1', name: 'Alpha' })])
+        const { paneEl, instance } = mount()
+
+        const menuAnchor = paneEl.querySelector<HTMLElement>('.navigation-side-panel-row-menu')
+        menuAnchor?.click()
+
+        expect(mocks.navigateTo).not.toHaveBeenCalled()
+
+        instance.destroy()
+    })
+})
+
+// =============================================================================
+// NAVIGATION AND WORKSPACE CREATION
+// =============================================================================
+
+describe('NavigationSidePanel — navigation and creation', () => {
+    it('navigates to the clicked workspace and resets its loading status to idle', () => {
+        workspacesStore.setWorkspaces([makeWorkspace({ workspaceId: 'ws-1', name: 'Alpha' })])
+        workspaceStore.setMetaValues({ loadingStatus: LoadingStatus.loading })
+        const { paneEl, instance } = mount()
+
+        paneEl.querySelector<HTMLButtonElement>('.navigation-side-panel-row')?.click()
+
+        expect(mocks.navigateTo).toHaveBeenCalledExactlyOnceWith('/workspace/:workspaceId', {
+            params: { workspaceId: 'ws-1' },
+            shouldFetchData: true,
+        })
+        expect(workspaceStore.getMeta('loadingStatus')).toBe(LoadingStatus.idle)
+
+        instance.destroy()
+    })
+
+    it('creates a new workspace when the header button is clicked', async () => {
+        const { paneEl, instance } = mount()
+
+        paneEl.querySelector<HTMLButtonElement>('.navigation-side-panel-new-workspace-button')?.click()
+        await Promise.resolve()
+
+        expect(mocks.createWorkspace).toHaveBeenCalledExactlyOnceWith({ name: 'New Workspace' })
+
+        instance.destroy()
+    })
+})
+
+// =============================================================================
+// ROW MENU ACTIONS — import / export / delete
+// =============================================================================
+
+describe('NavigationSidePanel — row menu actions', () => {
+    it('routes the Delete option to WorkspaceService.deleteWorkspace for that row', async () => {
+        workspacesStore.setWorkspaces([makeWorkspace({ workspaceId: 'ws-1', name: 'Alpha' })])
+        const { instance } = mount()
+
+        dropdownConfigFor('ws-1').onSelect({ title: 'Delete' })
+        await Promise.resolve()
+
+        expect(mocks.deleteWorkspace).toHaveBeenCalledExactlyOnceWith({ workspaceId: 'ws-1' })
+
+        instance.destroy()
+    })
+
+    it('routes the Import option to arming the hidden file input for that row, not to a service call', () => {
+        workspacesStore.setWorkspaces([makeWorkspace({ workspaceId: 'ws-1', name: 'Alpha' })])
+        const { paneEl, instance } = mount()
+        const input = paneEl.querySelector<HTMLInputElement>('.navigation-side-panel-import-input') as HTMLInputElement
+        const clickSpy = vi.spyOn(input, 'click').mockImplementation(() => undefined)
+
+        dropdownConfigFor('ws-1').onSelect({ title: 'Import' })
+
+        expect(clickSpy).toHaveBeenCalledTimes(1)
+        expect(mocks.deleteWorkspace).not.toHaveBeenCalled()
+        expect(mocks.getWorkspace).not.toHaveBeenCalled()
+
+        instance.destroy()
+    })
+
+    it('opens the export URL with a fresh auth token when Export is selected', async () => {
+        mocks.getTokenSilently.mockResolvedValue('token-123')
+        const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
+        workspacesStore.setWorkspaces([makeWorkspace({ workspaceId: 'ws-1', name: 'Alpha' })])
+        const { instance } = mount()
+
+        dropdownConfigFor('ws-1').onSelect({ title: 'Export' })
+        await Promise.resolve()
+        await Promise.resolve()
+
+        expect(openSpy).toHaveBeenCalledExactlyOnceWith(
+            expect.stringMatching(/\/api\/workspaces\/ws-1\/export\?token=token-123$/),
+            '_blank',
+        )
+
+        openSpy.mockRestore()
+        instance.destroy()
+    })
+
+    it('does not open the export URL when no auth token is available', async () => {
+        mocks.getTokenSilently.mockResolvedValue(null)
+        const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
+        workspacesStore.setWorkspaces([makeWorkspace({ workspaceId: 'ws-1', name: 'Alpha' })])
+        const { instance } = mount()
+
+        dropdownConfigFor('ws-1').onSelect({ title: 'Export' })
+        await Promise.resolve()
+        await Promise.resolve()
+
+        expect(openSpy).not.toHaveBeenCalled()
+
+        openSpy.mockRestore()
+        instance.destroy()
+    })
+})
+
+// =============================================================================
+// WORKSPACE IMPORT FLOW (hidden file input)
+// =============================================================================
+
+describe('NavigationSidePanel — workspace import flow', () => {
+    function selectFile(input: HTMLInputElement, file: File): void {
+        Object.defineProperty(input, 'files', { value: [file], configurable: true })
+        input.dispatchEvent(new Event('change'))
+    }
+
+    let fetchSpy: ReturnType<typeof vi.spyOn> | null = null
+
+    beforeEach(() => {
+        fetchSpy = vi.spyOn(globalThis, 'fetch') as unknown as ReturnType<typeof vi.spyOn>
+    })
+
+    afterEach(() => {
+        fetchSpy?.mockRestore()
+        fetchSpy = null
+    })
+
+    it('does nothing when a file is chosen without first arming an import target', async () => {
+        const { paneEl, instance } = mount()
+        const input = paneEl.querySelector<HTMLInputElement>('.navigation-side-panel-import-input') as HTMLInputElement
+
+        selectFile(input, new File(['zip'], 'workspace.zip'))
+        await Promise.resolve()
+
+        expect(fetchSpy).not.toHaveBeenCalled()
+
+        instance.destroy()
+    })
+
+    it('uploads the selected file with an auth bearer token to the target workspace', async () => {
+        mocks.getTokenSilently.mockResolvedValue('token-abc')
+        fetchSpy?.mockResolvedValue({ ok: true, json: async () => ({}) } as Response)
+        workspacesStore.setWorkspaces([makeWorkspace({ workspaceId: 'ws-1', name: 'Alpha' })])
+        const { paneEl, instance } = mount()
+        const input = paneEl.querySelector<HTMLInputElement>('.navigation-side-panel-import-input') as HTMLInputElement
+
+        dropdownConfigFor('ws-1').onSelect({ title: 'Import' })
+        selectFile(input, new File(['zip'], 'workspace.zip'))
+        await Promise.resolve()
+        await Promise.resolve()
+        await Promise.resolve()
+
+        expect(fetchSpy).toHaveBeenCalledExactlyOnceWith(
+            expect.stringMatching(/\/api\/workspaces\/ws-1\/import$/),
+            expect.objectContaining({
+                method: 'POST',
+                headers: { Authorization: 'Bearer token-abc' },
+            }),
+        )
+        const requestInit = fetchSpy?.mock.calls[0]?.[1] as RequestInit
+        const body = requestInit?.body
+        expect(body).toBeInstanceOf(FormData)
+        expect(body?.get('file')).toBeInstanceOf(File)
+        expect(body?.get('file')?.name).toBe('workspace.zip')
+
+        instance.destroy()
+    })
+
+    it('does not upload when no auth token is available', async () => {
+        mocks.getTokenSilently.mockResolvedValue(null)
+        workspacesStore.setWorkspaces([makeWorkspace({ workspaceId: 'ws-1', name: 'Alpha' })])
+        const { paneEl, instance } = mount()
+        const input = paneEl.querySelector<HTMLInputElement>('.navigation-side-panel-import-input') as HTMLInputElement
+
+        dropdownConfigFor('ws-1').onSelect({ title: 'Import' })
+        selectFile(input, new File(['zip'], 'workspace.zip'))
+        await Promise.resolve()
+        await Promise.resolve()
+
+        expect(fetchSpy).not.toHaveBeenCalled()
+
+        instance.destroy()
+    })
+
+    it('refreshes workspace, document, and AI chat thread data only when the import target is the currently open workspace', async () => {
+        mocks.getTokenSilently.mockResolvedValue('token-abc')
+        fetchSpy?.mockResolvedValue({ ok: true, json: async () => ({}) } as Response)
+        workspacesStore.setWorkspaces([makeWorkspace({ workspaceId: 'ws-1', name: 'Alpha' })])
+        setCurrentWorkspaceId('ws-1')
+        const { paneEl, instance } = mount()
+        const input = paneEl.querySelector<HTMLInputElement>('.navigation-side-panel-import-input') as HTMLInputElement
+
+        dropdownConfigFor('ws-1').onSelect({ title: 'Import' })
+        selectFile(input, new File(['zip'], 'workspace.zip'))
+        await Promise.resolve()
+        await Promise.resolve()
+        await Promise.resolve()
+        await Promise.resolve()
+
+        expect(mocks.getWorkspace).toHaveBeenCalledExactlyOnceWith({ workspaceId: 'ws-1' })
+        expect(mocks.getWorkspaceDocuments).toHaveBeenCalledExactlyOnceWith({ workspaceId: 'ws-1' })
+        expect(mocks.getWorkspaceAiChatThreads).toHaveBeenCalledExactlyOnceWith({ workspaceId: 'ws-1' })
+
+        instance.destroy()
+    })
+
+    it('does not refresh the open workspace when the import target is a different workspace', async () => {
+        mocks.getTokenSilently.mockResolvedValue('token-abc')
+        fetchSpy?.mockResolvedValue({ ok: true, json: async () => ({}) } as Response)
+        workspacesStore.setWorkspaces([
+            makeWorkspace({ workspaceId: 'ws-1', name: 'Alpha' }),
+            makeWorkspace({ workspaceId: 'ws-2', name: 'Beta' }),
+        ])
+        setCurrentWorkspaceId('ws-2')
+        const { paneEl, instance } = mount()
+        const input = paneEl.querySelector<HTMLInputElement>('.navigation-side-panel-import-input') as HTMLInputElement
+
+        dropdownConfigFor('ws-1').onSelect({ title: 'Import' })
+        selectFile(input, new File(['zip'], 'workspace.zip'))
+        await Promise.resolve()
+        await Promise.resolve()
+        await Promise.resolve()
+        await Promise.resolve()
+
+        expect(mocks.getWorkspace).not.toHaveBeenCalled()
+        expect(mocks.getWorkspaceDocuments).not.toHaveBeenCalled()
+        expect(mocks.getWorkspaceAiChatThreads).not.toHaveBeenCalled()
+
+        instance.destroy()
+    })
+
+    it('logs and does not attempt a refresh when the backend reports an import failure', async () => {
+        mocks.getTokenSilently.mockResolvedValue('token-abc')
+        fetchSpy?.mockResolvedValue({ ok: false, json: async () => ({ error: 'bad zip' }) } as Response)
+        workspacesStore.setWorkspaces([makeWorkspace({ workspaceId: 'ws-1', name: 'Alpha' })])
+        setCurrentWorkspaceId('ws-1')
+        const { paneEl, instance } = mount()
+        const input = paneEl.querySelector<HTMLInputElement>('.navigation-side-panel-import-input') as HTMLInputElement
+
+        dropdownConfigFor('ws-1').onSelect({ title: 'Import' })
+        selectFile(input, new File(['zip'], 'workspace.zip'))
+        await Promise.resolve()
+        await Promise.resolve()
+        await Promise.resolve()
+        await Promise.resolve()
+
+        expect(consoleErrorSpy).toHaveBeenCalledWith('Workspace import failed:', { error: 'bad zip' })
+        expect(mocks.getWorkspace).not.toHaveBeenCalled()
+
+        instance.destroy()
+    })
+
+    it('logs and swallows a network failure during upload instead of throwing', async () => {
+        mocks.getTokenSilently.mockResolvedValue('token-abc')
+        fetchSpy?.mockRejectedValue(new Error('network down'))
+        workspacesStore.setWorkspaces([makeWorkspace({ workspaceId: 'ws-1', name: 'Alpha' })])
+        const { paneEl, instance } = mount()
+        const input = paneEl.querySelector<HTMLInputElement>('.navigation-side-panel-import-input') as HTMLInputElement
+
+        dropdownConfigFor('ws-1').onSelect({ title: 'Import' })
+        selectFile(input, new File(['zip'], 'workspace.zip'))
+        await Promise.resolve()
+        await Promise.resolve()
+        await Promise.resolve()
+
+        expect(consoleErrorSpy).toHaveBeenCalledWith('Workspace import failed:', expect.any(Error))
+
+        instance.destroy()
+    })
+
+    it('clears the file input value and the import target before reading the next selection', () => {
+        workspacesStore.setWorkspaces([makeWorkspace({ workspaceId: 'ws-1', name: 'Alpha' })])
+        const { paneEl, instance } = mount()
+        const input = paneEl.querySelector<HTMLInputElement>('.navigation-side-panel-import-input') as HTMLInputElement
+
+        dropdownConfigFor('ws-1').onSelect({ title: 'Import' })
+
+        expect(input.value).toBe('')
+
+        instance.destroy()
+    })
+})
+
+// =============================================================================
+// TOGGLE OPEN/CLOSE
+// =============================================================================
+
+describe('NavigationSidePanel — open/close toggle', () => {
+    it('flips the persisted isOpen state when the toggle button is clicked', () => {
+        const { paneEl, instance } = mount()
+        expect(navigationSidePanelStore.getData('isOpen')).toBe(true)
+
+        paneEl.querySelector<HTMLButtonElement>('.navigation-side-panel-toggle')?.click()
+
+        expect(navigationSidePanelStore.getData('isOpen')).toBe(false)
+
+        paneEl.querySelector<HTMLButtonElement>('.navigation-side-panel-toggle')?.click()
+
+        expect(navigationSidePanelStore.getData('isOpen')).toBe(true)
+
+        instance.destroy()
+    })
+})
+
+// =============================================================================
+// DESTROY / CLEANUP
+// =============================================================================
+
+describe('NavigationSidePanel — destroy', () => {
+    it('removes the panel and its side-panel surfaces from the host pane', () => {
+        const { paneEl, instance } = mount()
+
+        instance.destroy()
+
+        expect(paneEl.querySelector('.navigation-side-panel')).toBeNull()
+        expect(paneEl.querySelector('.navigation-side-panel-toggle')).toBeNull()
+        expect(paneEl.querySelector('.side-panel-overlay')).toBeNull()
+        expect(paneEl.querySelector('.side-panel-backdrop')).toBeNull()
+    })
+
+    it('destroys every live row dropdown and stops reacting to store changes', () => {
+        workspacesStore.setWorkspaces([makeWorkspace({ workspaceId: 'ws-1', name: 'Alpha' })])
+        const { paneEl, instance } = mount()
+        const dropdown = liveDropdownFor('ws-1')
+
+        instance.destroy()
+
+        expect(dropdown.destroy).toHaveBeenCalledTimes(1)
+
+        // Store churn after destroy must not touch a torn-down DOM tree.
+        workspacesStore.setWorkspaces([makeWorkspace({ workspaceId: 'ws-2', name: 'Beta' })])
+        expect(paneEl.querySelector('.navigation-side-panel-row')).toBeNull()
+    })
+
+    it('stops listening for the import input change event after destroy', () => {
+        workspacesStore.setWorkspaces([makeWorkspace({ workspaceId: 'ws-1', name: 'Alpha' })])
+        const { paneEl, instance } = mount()
+        const input = paneEl.querySelector<HTMLInputElement>('.navigation-side-panel-import-input') as HTMLInputElement
+        dropdownConfigFor('ws-1').onSelect({ title: 'Import' })
+
+        instance.destroy()
+        Object.defineProperty(input, 'files', { value: [new File(['zip'], 'w.zip')], configurable: true })
+        input.dispatchEvent(new Event('change'))
+
+        expect(mocks.getTokenSilently).not.toHaveBeenCalled()
+    })
+})

--- a/services/web-ui/src/components/proseMirror/plugins/aiChatThreadPlugin/aiGeneratedImageNode.test.ts
+++ b/services/web-ui/src/components/proseMirror/plugins/aiChatThreadPlugin/aiGeneratedImageNode.test.ts
@@ -66,6 +66,11 @@ const createNodeView = (overrides: Record<string, unknown> = {}, getPos: () => n
     return { nodeView, node, dispatch, focus, state, doc, view: view as any }
 }
 
+const getImageSrc = (nodeView: { dom: HTMLElement }): string => {
+    const image = nodeView.dom.querySelector('.ai-generated-image-content') as HTMLImageElement
+    return image.getAttribute('src') ?? ''
+}
+
 // =============================================================================
 // aiGeneratedImageNodeSpec
 // =============================================================================
@@ -168,12 +173,13 @@ describe('aiGeneratedImageNodeView', () => {
             imageData: '/api/images/workspace-images/final-file',
             isPartial: false,
         })
-        const image = nodeView.dom.querySelector('.ai-generated-image-content') as HTMLImageElement
 
         await Promise.resolve()
+        await vi.waitFor(() => expect(getImageSrc(nodeView)).toContain('token=token-1'))
 
         expect(AuthService.getTokenSilently).toHaveBeenCalledTimes(1)
-        expect(image.src).toContain('/api/images/workspace-images/final-file?token=token-1')
+        expect(getImageSrc(nodeView)).toContain('/api/files/workspace-images/final-file')
+        expect(getImageSrc(nodeView)).toContain('token=token-1')
     })
 
     it('replaces stale tokenized image URLs with a refreshed token', async () => {
@@ -183,12 +189,11 @@ describe('aiGeneratedImageNodeView', () => {
             imageData: 'https://cdn.example.com/api/files/workspace-images/final-file?token=stale',
             isPartial: false,
         })
-        const image = nodeView.dom.querySelector('.ai-generated-image-content') as HTMLImageElement
 
         await Promise.resolve()
 
-        expect(image.src).not.toContain('token=stale')
-        expect(image.src).toContain('token=fresh-token')
+        await vi.waitFor(() => expect(getImageSrc(nodeView)).toContain('token=fresh-token'))
+        expect(getImageSrc(nodeView)).not.toContain('token=stale')
     })
 
     it('keeps non-file HTTP URLs unchanged when they include query params', async () => {
@@ -265,7 +270,22 @@ describe('aiGeneratedImageNodeView', () => {
         expect(updated).toBe(true)
         expect(spinner.classList.contains('is-active')).toBe(false)
         expect(image.classList.contains('is-visible')).toBe(true)
-        expect(image.src).toContain('/api/images/workspace-images/new-file?token=token-1')
+        await vi.waitFor(() => expect(getImageSrc(nodeView)).toContain('/api/files/workspace-images/new-file'))
+        expect(getImageSrc(nodeView)).toContain('token=token-1')
+    })
+
+    it('does not request auth tokens for plain external URLs', async () => {
+        vi.mocked(AuthService.getTokenSilently).mockReset().mockResolvedValue('token-1')
+        const { nodeView } = createNodeView({
+            imageData: 'https://cdn.example.com/preview/public-image.png',
+            isPartial: false,
+        })
+        const image = nodeView.dom.querySelector('.ai-generated-image-content') as HTMLImageElement
+
+        await Promise.resolve()
+
+        expect(AuthService.getTokenSilently).not.toHaveBeenCalled()
+        expect(image.getAttribute('src')).toBe('https://cdn.example.com/preview/public-image.png')
     })
 
     it('adds an inline error placeholder only once when image fails to load', async () => {

--- a/services/web-ui/src/components/proseMirror/plugins/aiChatThreadPlugin/aiGeneratedImageNode.ts
+++ b/services/web-ui/src/components/proseMirror/plugins/aiChatThreadPlugin/aiGeneratedImageNode.ts
@@ -1,5 +1,6 @@
 import { brokenImageIcon } from '$src/svgIcons/index.ts'
 import { html, applyStyle } from '$src/utils/domTemplates.ts'
+import { resolveAuthenticatedMediaUrl } from '$src/utils/workspaceFileUrls.ts'
 import AuthService from '$src/services/auth-service.ts'
 import { settings } from '$src/settings.ts'
 import { applyMediaModelBadgeStyleProperties, renderMediaModelBadge } from '$src/components/mediaModelBadge.ts'
@@ -152,28 +153,11 @@ export const aiGeneratedImageNodeView = (node: any, view: any, getPos: () => num
         spinnerElement.classList.remove('is-active')
         imageElement.classList.add('is-visible')
 
-        // imageData is now a URL path like /api/files/workspaceId/fileId
-        // It can also be a data URL or base64 for backwards compatibility
-        let imageSrc: string
-        if (imageData.startsWith('data:')) {
-            imageSrc = imageData
-        } else if (imageData.startsWith('/api/')) {
-            const token = await AuthService.getTokenSilently()
-            const API_BASE_URL = import.meta.env.VITE_API_URL || ''
-            imageSrc = `${API_BASE_URL}${imageData}${token ? `?token=${token}` : ''}`
-        } else if (imageData.startsWith('http')) {
-            // Full URL — strip any stale token and re-apply a fresh one
-            const stripped = imageData.replace(/[?&]token=[^&]+/, '')
-            if (stripped.includes('/api/files/')) {
-                const token = await AuthService.getTokenSilently()
-                imageSrc = `${stripped}${token ? `?token=${token}` : ''}`
-            } else {
-                imageSrc = imageData
-            }
-        } else {
-            // Legacy base64 data
-            imageSrc = `data:image/png;base64,${imageData}`
-        }
+        const imageSrc = await resolveAuthenticatedMediaUrl(imageData, {
+            apiBaseUrl: import.meta.env.VITE_API_URL || '',
+            base64MimeType: 'image/png',
+            getAuthToken: () => AuthService.getTokenSilently(),
+        })
 
         if (imageElement.src !== imageSrc) {
             imageElement.src = imageSrc

--- a/services/web-ui/src/components/proseMirror/plugins/aiChatThreadPlugin/aiGeneratedVideoNode.test.ts
+++ b/services/web-ui/src/components/proseMirror/plugins/aiChatThreadPlugin/aiGeneratedVideoNode.test.ts
@@ -224,13 +224,13 @@ describe('aiGeneratedVideoNodeView', () => {
         expect(view.stopEvent!({ target: container } as Event)).toBe(false)
     })
 
-    it('cleans up controls and listeners on destroy', async () => {
+    it('creates controls when ready and destroys them on cleanup', async () => {
         const view = createNodeView({
             isPending: false,
             videoUrl: 'data:video/mp4;base64,AAAA',
             errorMessage: '',
         })
-        await Promise.resolve()
+        await vi.waitFor(() => expect(vi.mocked(createVideoControls)).toHaveBeenCalled())
 
         view.destroy()
 
@@ -258,7 +258,7 @@ describe('aiGeneratedVideoNodeView', () => {
         expect(resolvedPosterSrc).not.toContain('token=stale')
     })
 
-    it('does not refresh non-file full URLs for legacy video/http sources', async () => {
+    it('refreshes API urls but preserves non-API poster URLs', async () => {
         const view = createNodeView({
             isPending: false,
             videoUrl: 'https://cdn.example.com/api/videos/workspace-id/video.mp4?token=stale',
@@ -270,7 +270,7 @@ describe('aiGeneratedVideoNodeView', () => {
 
         await vi.waitFor(() => {
             const resolvedVideoSrc = video.getAttribute('src') || video.src
-            expect(resolvedVideoSrc).toContain('token=stale')
+            expect(resolvedVideoSrc).toContain('token=token-1')
         })
 
         const resolvedPosterSrc = video.poster || video.getAttribute('poster')

--- a/services/web-ui/src/components/proseMirror/plugins/aiChatThreadPlugin/aiGeneratedVideoNode.ts
+++ b/services/web-ui/src/components/proseMirror/plugins/aiChatThreadPlugin/aiGeneratedVideoNode.ts
@@ -1,5 +1,6 @@
 import { brokenImageIcon } from '$src/svgIcons/index.ts'
 import { html, applyStyle } from '$src/utils/domTemplates.ts'
+import { resolveAuthenticatedMediaUrl } from '$src/utils/workspaceFileUrls.ts'
 import AuthService from '$src/services/auth-service.ts'
 import { settings } from '$src/settings.ts'
 import { NodeSelection } from 'prosemirror-state'
@@ -96,26 +97,11 @@ export function getAiGeneratedVideoCallbacks(): AiGeneratedVideoCallbacks {
     return globalCallbacks
 }
 
-// Resolves a path like /api/files/{ws}/{fileId} or /api/files/... to a full
-// authenticated URL. Mirrors the helper inlined in aiGeneratedImageNode.ts so
-// the same auth-token attachment logic applies to both video and poster URLs.
 const buildAuthenticatedUrl = async (url: string): Promise<string> => {
-    if (!url) return ''
-    if (url.startsWith('data:') || url.startsWith('blob:')) return url
-    if (url.startsWith('/api/')) {
-        const token = await AuthService.getTokenSilently()
-        const API_BASE_URL = import.meta.env.VITE_API_URL || ''
-        return `${API_BASE_URL}${url}${token ? `?token=${token}` : ''}`
-    }
-    if (url.startsWith('http')) {
-        const stripped = url.replace(/[?&]token=[^&]+/, '')
-        if (stripped.includes('/api/files/')) {
-            const token = await AuthService.getTokenSilently()
-            return `${stripped}${token ? `?token=${token}` : ''}`
-        }
-        return url
-    }
-    return url
+    return resolveAuthenticatedMediaUrl(url, {
+        apiBaseUrl: import.meta.env.VITE_API_URL || '',
+        getAuthToken: () => AuthService.getTokenSilently(),
+    })
 }
 
 export const aiGeneratedVideoNodeView = (node: any, view: any, getPos: () => number | undefined) => {

--- a/services/web-ui/src/components/proseMirror/plugins/aiChatThreadPlugin/imageGenerationTraceDetails.test.ts
+++ b/services/web-ui/src/components/proseMirror/plugins/aiChatThreadPlugin/imageGenerationTraceDetails.test.ts
@@ -3,7 +3,11 @@
 import { describe, it, expect, vi } from 'vitest'
 
 import {
+    cacheImageGenerationTrace,
     createImageGenerationTraceDetails,
+    formatImageGenerationTraceReferenceSource,
+    formatImageGenerationTraceRole,
+    getImageGenerationTrace,
     formatTraceModelLabel,
     type ImageGenerationTraceDetailsAttrs,
 } from '$src/components/proseMirror/plugins/aiChatThreadPlugin/imageGenerationTraceDetails.ts'
@@ -285,5 +289,65 @@ describe('formatTraceModelLabel', () => {
         expect(formatTraceModelLabel('')).toBe('')
         expect(formatTraceModelLabel(undefined)).toBe('')
         expect(formatTraceModelLabel(null)).toBe('')
+    })
+})
+
+describe('formatImageGenerationTraceRole', () => {
+    it('formats role strings into displayable labels', () => {
+        expect(formatImageGenerationTraceRole('target')).toBe('Target')
+        expect(formatImageGenerationTraceRole('style-reference')).toBe('Style Reference')
+        expect(formatImageGenerationTraceRole('context-only')).toBe('Context Only')
+        expect(formatImageGenerationTraceRole('')).toBe('')
+    })
+})
+
+describe('formatImageGenerationTraceReferenceSource', () => {
+    it('maps known reference sources to stable human labels', () => {
+        expect(formatImageGenerationTraceReferenceSource('branch-candidate')).toBe('Image from this branch')
+        expect(formatImageGenerationTraceReferenceSource('feature-reference')).toBe('Feature reference image')
+        expect(formatImageGenerationTraceReferenceSource('message-reference')).toBe('Attached to chat message')
+        expect(formatImageGenerationTraceReferenceSource('unknown-source')).toBe('Reference image')
+    })
+})
+
+describe('trace cache and fallback helpers', () => {
+    it('prefers cache lookups when imageGenerationTraceId is provided', () => {
+        const cachedTrace = makeTrace([makeReference({ id: 'cached', label: 'Cached trace image' })])
+        const inlineTrace = makeTrace([makeReference({ id: 'inline', label: 'Inline trace image' })])
+        cacheImageGenerationTrace('trace-1', cachedTrace)
+
+        const resolved = getImageGenerationTrace({
+            title: 'Image generation prompt',
+            isOpen: false,
+            isStreaming: false,
+            imageGenerationTraceId: 'trace-1',
+            imageGenerationTrace: inlineTrace,
+        })
+
+        expect(resolved).toBe(cachedTrace)
+        expect((resolved?.referenceImages[0] as ImageGenerationTraceReference).label).toBe('Cached trace image')
+    })
+
+    it('falls back to inline trace when no trace ID is supplied', () => {
+        const inlineTrace = makeTrace([makeReference({ id: 'inline', label: 'Inline trace image' })])
+
+        const resolved = getImageGenerationTrace({
+            title: 'Image generation prompt',
+            isOpen: false,
+            isStreaming: false,
+            imageGenerationTrace: inlineTrace,
+        })
+
+        expect(resolved).toBe(inlineTrace)
+    })
+
+    it('returns null when cached trace id is missing and no inline trace exists', () => {
+        const resolved = getImageGenerationTrace({
+            title: 'Image generation prompt',
+            isOpen: false,
+            isStreaming: false,
+            imageGenerationTraceId: 'missing',
+        })
+        expect(resolved).toBeNull()
     })
 })

--- a/services/web-ui/src/components/proseMirror/plugins/aiChatThreadPlugin/imageGenerationTraceDetails.ts
+++ b/services/web-ui/src/components/proseMirror/plugins/aiChatThreadPlugin/imageGenerationTraceDetails.ts
@@ -7,6 +7,7 @@ import type {
 
 import AuthService from '$src/services/auth-service.ts'
 import { html } from '$src/utils/domTemplates.ts'
+import { resolveAuthenticatedMediaUrl } from '$src/utils/workspaceFileUrls.ts'
 
 // Image and video generation traces share an identical reference/excluded/
 // resolver/prompt shape, so this renderer is reused verbatim for both media
@@ -84,28 +85,6 @@ export const formatTraceModelLabel = (modelId?: string | null): string => {
     return parts[1] || parts[0] || ''
 }
 
-const appendAuthenticatedToken = async (imageUrl: string): Promise<string> => {
-    const token = await AuthService.getTokenSilently()
-    if (!token) return imageUrl
-    const isAbsoluteUrl = /^[a-z][a-z0-9+.-]*:\/\//i.test(imageUrl)
-
-    try {
-        const url = isAbsoluteUrl ? new URL(imageUrl) : new URL(imageUrl, window.location.origin)
-        url.searchParams.set('token', token)
-        if (isAbsoluteUrl) return url.toString()
-        return `${url.pathname}${url.search}${url.hash}`
-    } catch {
-        const separator = imageUrl.includes('?') ? '&' : '?'
-        return `${imageUrl}${separator}token=${encodeURIComponent(token)}`
-    }
-}
-
-const buildAuthenticatedImageUrl = async (path: string): Promise<string> => {
-    const apiBaseUrl = (import.meta.env.VITE_API_URL || '').replace(/\/$/, '')
-    const sourceUrl = path.startsWith('http') || !apiBaseUrl ? path : `${apiBaseUrl}${path}`
-    return appendAuthenticatedToken(sourceUrl)
-}
-
 const getReferenceWorkspaceImagePath = (reference: ImageGenerationTraceReference): string | null => {
     if (reference.fileId && reference.workspaceId) {
         return `/api/files/${encodeURIComponent(reference.workspaceId)}/${encodeURIComponent(reference.fileId)}`
@@ -120,14 +99,6 @@ const getNatsWorkspaceImagePath = (imageUrl: string): string | null => {
     const [, workspaceId, objectKey] = match
     if (!workspaceId || !objectKey || objectKey.includes('/')) return null
     return `/api/files/${encodeURIComponent(workspaceId)}/${encodeURIComponent(objectKey)}`
-}
-
-const isApiHttpUrl = (imageUrl: string): boolean => {
-    try {
-        return new URL(imageUrl).pathname.startsWith('/api/')
-    } catch {
-        return imageUrl.includes('/api/')
-    }
 }
 
 const uniqueImageSources = (sources: string[]): string[] => {
@@ -151,17 +122,14 @@ const getReferenceImageSources = (
 }
 
 const resolveReferenceImageSrc = async (imageUrl: string): Promise<string> => {
-    if (imageUrl.startsWith('data:') || imageUrl.startsWith('blob:')) return imageUrl
-    if (imageUrl.startsWith('/api/')) return buildAuthenticatedImageUrl(imageUrl)
-    if (imageUrl.startsWith('http') && isApiHttpUrl(imageUrl)) {
-        return appendAuthenticatedToken(imageUrl)
-    }
-    if (imageUrl.startsWith('http')) return imageUrl
-    if (imageUrl.startsWith('nats-obj://')) {
-        const path = getNatsWorkspaceImagePath(imageUrl)
-        return path ? buildAuthenticatedImageUrl(path) : ''
-    }
-    return imageUrl
+    const source = imageUrl.startsWith('nats-obj://')
+        ? getNatsWorkspaceImagePath(imageUrl) ?? ''
+        : imageUrl
+
+    return resolveAuthenticatedMediaUrl(source, {
+        apiBaseUrl: import.meta.env.VITE_API_URL || '',
+        getAuthToken: () => AuthService.getTokenSilently(),
+    })
 }
 
 const resolveReferenceImageSources = async (

--- a/services/web-ui/src/components/proseMirror/plugins/imageSelectionPlugin/imageNodeView.test.ts
+++ b/services/web-ui/src/components/proseMirror/plugins/imageSelectionPlugin/imageNodeView.test.ts
@@ -1,135 +1,273 @@
 'use strict'
 
-import { describe, it, expect } from 'vitest'
-import { readFileSync } from 'fs'
-import { resolve } from 'path'
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest'
+import { EditorState } from 'prosemirror-state'
+import type { Node as ProseMirrorNode } from 'prosemirror-model'
+import { testSchema } from '$src/components/proseMirror/plugins/testUtils/testSchema.ts'
+import { ImageNodeView } from '$src/components/proseMirror/plugins/imageSelectionPlugin/imageNodeView.ts'
+import AuthService from '$src/services/auth-service.ts'
+import { aiModelsStore } from '$src/stores/aiModelsStore.ts'
 
-// =============================================================================
-// HELPERS
-// =============================================================================
+vi.mock('$src/services/auth-service.ts', () => ({
+    default: {
+        getTokenSilently: vi.fn(),
+    },
+}))
 
-function loadTs(): string {
-	return readFileSync(
-		resolve(__dirname, 'imageNodeView.ts'),
-		'utf-8'
-	)
+afterEach(() => {
+    vi.clearAllMocks()
+})
+
+beforeEach(() => {
+    vi.mocked(AuthService.getTokenSilently).mockReset().mockResolvedValue('token-1')
+})
+
+const createImageNode = (overrides: Record<string, unknown> = {}): ProseMirrorNode => {
+    return testSchema.nodes.image.create({
+        src: 'https://cdn.example.com/example.jpg',
+        alt: 'Example source image',
+        title: '',
+        ...overrides,
+    })
+}
+
+const createGeneratedImageNode = (overrides: Record<string, unknown> = {}): ProseMirrorNode => {
+    return testSchema.nodes.aiGeneratedImage.create({
+        imageData: '/api/images/workspace-1/final-file',
+        fileId: 'generated-file',
+        workspaceId: 'workspace-1',
+        revisedPrompt: 'final generated image',
+        responseId: 'response-1',
+        isPartial: false,
+        partialIndex: 0,
+        generationRequestId: '',
+        reasoningRunId: '',
+        mediaRunId: '',
+        reasoningModelId: '',
+        mediaModelId: 'Google:gemini-2.5-flash',
+        mediaType: 'image',
+        variantIndex: null,
+        alignment: 'left',
+        textWrap: 'none',
+        ...overrides,
+    })
+}
+
+const createImageView = (node: ProseMirrorNode, editable = true, getPos: () => number | undefined = () => 0) => {
+    const doc = testSchema.nodes.doc.create(null, [node])
+    const state = EditorState.create({ doc, schema: testSchema })
+    const dispatch = vi.fn()
+    const focus = vi.fn()
+    const view = {
+        state,
+        dispatch,
+        focus,
+        editable,
+        dom: document.createElement('div'),
+    }
+
+    const nodeView = new ImageNodeView({
+        node,
+        view: view as any,
+        getPos,
+    })
+
+    return {
+        nodeView,
+        node,
+        doc,
+        state,
+        dispatch,
+        focus,
+        view: view as any,
+    }
+}
+
+const getImageElement = (nodeView: ImageNodeView): HTMLImageElement => {
+    return nodeView.dom.querySelector('img') as HTMLImageElement
+}
+
+const getResolvedImageSrc = (nodeView: ImageNodeView): string => {
+    return getImageElement(nodeView).getAttribute('src') ?? ''
 }
 
 // =============================================================================
-// Imports — brokenImageIcon from svgIcons, html from domTemplates
+// Initialization and source resolution
 // =============================================================================
 
-describe('ImageNodeView — imports', () => {
-	const ts = loadTs()
+describe('ImageNodeView — initialization and source resolution', () => {
+    it('keeps inline data URLs untouched and skips auth for them', async () => {
+        const imageData = 'data:image/png;base64,AAABBB'
+        const { nodeView } = createImageView(testSchema.nodes.image.create({
+            src: imageData,
+            alt: '',
+            title: '',
+        }))
 
-	it('imports brokenImageIcon from svgIcons', () => {
-		expect(ts).toMatch(/import\s*\{[^}]*brokenImageIcon[^}]*\}\s*from\s*['"]\$src\/svgIcons\/index\.ts['"]/)
-	})
+        await vi.waitFor(() => expect(getImageElement(nodeView).getAttribute('src')).toBe(imageData))
+        expect(AuthService.getTokenSilently).not.toHaveBeenCalled()
+    })
 
-	it('imports html from domTemplates', () => {
-		expect(ts).toMatch(/import\s*\{[^}]*html[^}]*\}\s*from\s*['"]\$src\/utils\/domTemplates\.ts['"]/)
-	})
+    it('resolves API image paths through resolveAuthenticatedMediaUrl', async () => {
+        const { nodeView } = createImageView(createImageNode({
+            src: '/api/images/workspace-1/final-file',
+        }))
+
+        await vi.waitFor(() => expect(getResolvedImageSrc(nodeView)).toContain('token=token-1'))
+        expect(getResolvedImageSrc(nodeView)).toContain('/api/files/workspace-1/final-file')
+        expect(AuthService.getTokenSilently).toHaveBeenCalledTimes(1)
+    })
+
+    it('updates resolved image source when image node attrs change', async () => {
+        const { nodeView } = createImageView(createImageNode({
+            src: '/api/images/workspace-1/old',
+        }))
+
+        await vi.waitFor(() => expect(getResolvedImageSrc(nodeView)).toContain('/api/files/workspace-1/old'))
+
+        const updated = nodeView.update(createImageNode({
+            src: '/api/images/workspace-1/new',
+        }))
+        expect(updated).toBe(true)
+
+        await vi.waitFor(() => expect(getResolvedImageSrc(nodeView)).toContain('/api/files/workspace-1/new'))
+    })
 })
 
 // =============================================================================
-// Image error placeholder — uses html template + innerHTML for SVG
+// Generated media chrome and placeholder behavior
 // =============================================================================
 
-describe('ImageNodeView — error placeholder', () => {
-	const ts = loadTs()
+describe('ImageNodeView — generated image behaviors', () => {
+    it('renders generation placeholders only while partial data is absent', () => {
+        const { nodeView } = createImageView(createGeneratedImageNode({
+            imageData: '',
+            isPartial: true,
+        }))
 
-	it('uses html template for the error placeholder, not document.createElement', () => {
-		// Find the error handler block
-		const errorBlock = ts.match(/this\.img\.addEventListener\('error'[\s\S]*?\n\s*\}\)\n\n\s*\/\/ Handle selection/)
-		expect(errorBlock).not.toBeNull()
-		const block = errorBlock![0]
+        const placeholder = nodeView.dom.querySelector('.pm-image-generating-placeholder')
+        const title = nodeView.dom.querySelector('.ai-generated-media-section-title')
+        const image = getImageElement(nodeView)
 
-		expect(block).toContain('html`')
-		expect(block).not.toContain('document.createElement')
-	})
+        expect(nodeView.dom.classList.contains('is-partial')).toBe(true)
+        expect(placeholder).not.toBeNull()
+        expect(title).toBeNull()
+        expect(image.style.display).toBe('none')
+    })
 
-	it('injects brokenImageIcon via innerHTML attribute, not string interpolation', () => {
-		const errorBlock = ts.match(/this\.img\.addEventListener\('error'[\s\S]*?\n\s*\}\)\n\n\s*\/\/ Handle selection/)
-		expect(errorBlock).not.toBeNull()
-		const block = errorBlock![0]
+    it('shows the generated-image title when complete image data is present', async () => {
+        const { nodeView } = createImageView(createGeneratedImageNode({
+            imageData: '',
+            isPartial: true,
+        }))
 
-		expect(block).toContain('innerHTML=${brokenImageIcon}')
-	})
+        const updated = nodeView.update(createGeneratedImageNode({
+            imageData: 'https://cdn.example.com/final-generated.png',
+            isPartial: false,
+        }))
 
-	it('checks for existing placeholder before appending (deduplication)', () => {
-		const errorBlock = ts.match(/this\.img\.addEventListener\('error'[\s\S]*?\n\s*\}\)\n\n\s*\/\/ Handle selection/)
-		expect(errorBlock).not.toBeNull()
-		const block = errorBlock![0]
+        expect(updated).toBe(true)
+        await vi.waitFor(() => expect(nodeView.dom.querySelector('.ai-generated-media-section-title')).not.toBeNull())
+    })
 
-		expect(block).toContain(".querySelector('.image-error-placeholder')")
-	})
+    it('shows generated model chrome and updates it when media model changes', async () => {
+        const { nodeView } = createImageView(createGeneratedImageNode({
+            mediaModelId: 'Google:gemini-2.5-flash',
+        }))
 
-	it('hides the img element on error', () => {
-		const errorBlock = ts.match(/this\.img\.addEventListener\('error'[\s\S]*?\n\s*\}\)\n\n\s*\/\/ Handle selection/)
-		expect(errorBlock).not.toBeNull()
-		const block = errorBlock![0]
+        await vi.waitFor(() => expect(getImageElement(nodeView).getAttribute('src')).toContain('token=token-1'))
+        const modelChrome = nodeView.dom.querySelector('.ai-generated-media-run-meta') as HTMLElement
+        expect(modelChrome).not.toBeNull()
+        expect(modelChrome.textContent).toContain('Google')
 
-		expect(block).toContain("applyStyle(this.img, { display: 'none' })")
-	})
+        nodeView.update(createGeneratedImageNode({
+            mediaModelId: 'OpenAI:gpt-4.1',
+        }))
+        expect(modelChrome.textContent).toContain('OpenAI')
+        expect(modelChrome.textContent).toContain('gpt-4.1')
+    })
 
-	it('no inline SVG markup in source', () => {
-		const errorBlock = ts.match(/this\.img\.addEventListener\('error'[\s\S]*?\n\s*\}\)\n\n\s*\/\/ Handle selection/)
-		expect(errorBlock).not.toBeNull()
-		const block = errorBlock![0]
+    it('adds an unavailable placeholder and keeps it deduplicated on repeated image errors', () => {
+        const { nodeView } = createImageView(createImageNode({
+            src: '/api/images/workspace-1/not-found.jpg',
+        }))
+        const image = getImageElement(nodeView)
 
-		expect(block).not.toContain('<svg')
-		expect(block).not.toContain('viewBox')
-	})
+        image.dispatchEvent(new Event('error'))
+        image.dispatchEvent(new Event('error'))
+
+        const placeholders = nodeView.dom.querySelectorAll('.image-error-placeholder')
+        expect(placeholders).toHaveLength(1)
+    })
 })
 
 // =============================================================================
-// Partial generated image placeholder
+// Interaction and state transitions
 // =============================================================================
 
-describe('ImageNodeView — partial generated image placeholder', () => {
-	const ts = loadTs()
+describe('ImageNodeView — interactions', () => {
+    it('selects the node and focuses editor when clicked while editable', () => {
+        const { nodeView, dispatch, focus, view } = createImageView(createImageNode())
 
-	it('renders a generating placeholder for partial image nodes without image data', () => {
-		expect(ts).toContain('syncPartialPlaceholder')
-		expect(ts).toContain('pm-image-generating-placeholder')
-		expect(ts).toContain('pm-image-generating-dot')
-		expect(ts).toContain('Boolean(this.node.attrs.isPartial) && !getImageSrcAttr(this.node)')
-	})
+        nodeView.dom.dispatchEvent(new MouseEvent('click'))
 
-	it('does not assign an empty string as an img src', () => {
-		const updateBlock = ts.match(/private async updateImageSrc[\s\S]*?\n    \}/)
-		expect(updateBlock).not.toBeNull()
-		const block = updateBlock![0]
+        expect(dispatch).toHaveBeenCalledTimes(1)
+        expect(focus).toHaveBeenCalledTimes(1)
+        expect(view.state.tr).toBeDefined()
+        expect(dispatch.mock.calls[0]?.[0].selection.toJSON()).toMatchObject({
+            type: 'node',
+            anchor: 0,
+        })
+    })
 
-		expect(block).toContain("if (!src)")
-		expect(block).toContain("this.img.removeAttribute('src')")
-		expect(block).toContain("applyStyle(this.img, { display: 'none' })")
-	})
+    it('does not dispatch selection when editor is read-only', () => {
+        const { nodeView, dispatch, focus } = createImageView(createImageNode(), false)
+
+        nodeView.dom.dispatchEvent(new MouseEvent('click'))
+
+        expect(dispatch).not.toHaveBeenCalled()
+        expect(focus).not.toHaveBeenCalled()
+    })
+
+    it('allows all events except resize handle events to bubble through stopEvent', () => {
+        const { nodeView } = createImageView(createImageNode())
+        const handle = nodeView.dom.querySelector('.pm-image-resize-handle')
+        const container = nodeView.dom.querySelector('.pm-image-media-frame') as HTMLElement
+
+        expect(handle).not.toBeNull()
+        expect(nodeView.stopEvent({ target: handle as unknown as HTMLElement } as Event)).toBe(true)
+        expect(nodeView.stopEvent({ target: container } as Event)).toBe(false)
+    })
 })
 
 // =============================================================================
-// buildImageSrc — handles various URL formats
+// Lifecycle and cleanup
 // =============================================================================
 
-describe('ImageNodeView — buildImageSrc', () => {
-	const ts = loadTs()
+describe('ImageNodeView — lifecycle cleanup', () => {
+    it('does not render resize handles when the editor is not editable', () => {
+        const { nodeView } = createImageView(createImageNode(), false)
 
-	it('returns empty string for empty src', () => {
-		expect(ts).toMatch(/if\s*\(\s*!src\s*\)\s*return\s*['"]/)
-	})
+        expect(nodeView.dom.querySelectorAll('.pm-image-resize-handle')).toHaveLength(0)
+    })
 
-	it('passes through data: and blob: URLs without auth', () => {
-		expect(ts).toContain("src.startsWith('data:')")
-		expect(ts).toContain("src.startsWith('blob:')")
-	})
+    it('removes resize handles and unsubscribes model badge updates on destroy', () => {
+        const unsubscribe = vi.fn()
+        const subscribeSpy = vi.spyOn(aiModelsStore, 'subscribe').mockReturnValue(unsubscribe)
 
-	it('prepends API base URL and appends token for /api/ paths', () => {
-		expect(ts).toContain("src.startsWith('/api/')")
-		expect(ts).toContain('`${API_BASE_URL}${src}')
-	})
+        const { nodeView } = createImageView(createGeneratedImageNode())
 
-	it('strips stale tokens from full URLs pointing to /api/files/', () => {
-		expect(ts).toContain("src.includes('/api/files/')")
-		expect(ts).toMatch(/src\.replace\([^)]*token[^)]*\)/)
-	})
+        nodeView.destroy()
+
+        expect(unsubscribe).toHaveBeenCalledTimes(1)
+        expect(nodeView.dom.querySelectorAll('.pm-image-resize-handle')).toHaveLength(0)
+        subscribeSpy.mockRestore()
+    })
+
+    it('rejects incompatible nodes in update()', () => {
+        const { nodeView, doc } = createImageView(createImageNode())
+        const wrongNode = doc.type.schema.nodes.doc.create(null)
+
+        expect(nodeView.update(wrongNode as ProseMirrorNode)).toBe(false)
+    })
 })

--- a/services/web-ui/src/components/proseMirror/plugins/imageSelectionPlugin/imageNodeView.ts
+++ b/services/web-ui/src/components/proseMirror/plugins/imageSelectionPlugin/imageNodeView.ts
@@ -4,6 +4,7 @@ import { NodeSelection } from 'prosemirror-state'
 import { imageResizeCornerIcon, brokenImageIcon } from '$src/svgIcons/index.ts'
 import AuthService from '$src/services/auth-service.ts'
 import { html, applyStyle } from '$src/utils/domTemplates.ts'
+import { resolveAuthenticatedMediaUrl } from '$src/utils/workspaceFileUrls.ts'
 import { settings } from '$src/settings.ts'
 import { applyMediaModelBadgeStyleProperties, renderMediaModelBadge } from '$src/components/mediaModelBadge.ts'
 import { aiModelsStore } from '$src/stores/aiModelsStore.ts'
@@ -25,33 +26,10 @@ function getImageSrcAttr(node: ProseMirrorNode): string {
 
 // Build image src with auth token if needed
 async function buildImageSrc(src: string): Promise<string> {
-    if (!src) return ''
-
-    // Data URLs or blob URLs don't need auth
-    if (src.startsWith('data:') || src.startsWith('blob:')) {
-        return src
-    }
-
-    // API paths need auth token
-    if (src.startsWith('/api/')) {
-        const token = await AuthService.getTokenSilently()
-        const API_BASE_URL = import.meta.env.VITE_API_URL || ''
-        return `${API_BASE_URL}${src}${token ? `?token=${encodeURIComponent(token)}` : ''}`
-    }
-
-    // Full URLs pointing to /api/files/ — strip stale token and re-apply fresh one
-    if (src.startsWith('http') && src.includes('/api/files/')) {
-        const stripped = src.replace(/[?&]token=[^&]+/, '')
-        const token = await AuthService.getTokenSilently()
-        return `${stripped}${token ? `?token=${encodeURIComponent(token)}` : ''}`
-    }
-
-    // External URLs or already full URLs
-    if (src.startsWith('http')) {
-        return src
-    }
-
-    return src
+    return resolveAuthenticatedMediaUrl(src, {
+        apiBaseUrl: import.meta.env.VITE_API_URL || '',
+        getAuthToken: () => AuthService.getTokenSilently(),
+    })
 }
 
 export class ImageNodeView implements NodeView {

--- a/services/web-ui/src/infographics/workspace/README.md
+++ b/services/web-ui/src/infographics/workspace/README.md
@@ -465,13 +465,13 @@ When an image node, video node, or edge is selected on the canvas, a bubble menu
 
 ### Image Node Actions
 - **Create Variant** — dispatches a `canvas-create-image-variant` custom event on the viewport element
-- **Download** — fetches the image as a blob and triggers a browser download via `downloadImage()` utility
+- **Download** — downloads the stored file through the authenticated `/api/files` attachment route
 - **Add to Media Library** — saves a completed stored image as an independent library copy
 - **Delete** — removes the node and its associated edges from canvas state
 
 ### Video Node Actions
 - **Replace** — uploads a new video for the selected node, swaps the MP4/poster IDs on the existing node, and keeps the node in place
-- **Download** — downloads the stored MP4 through the Range-capable file route with `download=true`
+- **Download** — downloads the stored MP4 through the authenticated `/api/files` attachment route
 - **Add to Media Library** — saves a completed stored video and poster as independent library copies
 - **Connect to node** — starts the same menu-driven graph connection flow as images
 - **Delete** — removes the node and its associated edges from canvas state

--- a/services/web-ui/src/infographics/workspace/WorkspaceCanvas.ts
+++ b/services/web-ui/src/infographics/workspace/WorkspaceCanvas.ts
@@ -131,6 +131,12 @@ import { settings, type WorkspaceCollisionFlowSettings, type WorkspaceCollisionN
 import { BubbleMenu, type BubbleMenuPositionRequest } from '$src/components/bubbleMenu/index.ts'
 import { buildCanvasBubbleMenuItems, CANVAS_IMAGE_CONTEXT, CANVAS_VIDEO_CONTEXT, CANVAS_DOCUMENT_CONTEXT, CANVAS_AUDIO_CONTEXT, CANVAS_EDGE_CONTEXT } from '$src/infographics/workspace/canvasBubbleMenuItems.ts'
 import { downloadImage } from '$src/utils/downloadImage.ts'
+import {
+    buildWorkspaceFilePath,
+    buildWorkspaceFilesPath,
+    isWorkspaceFileEndpoint,
+    resolveMediaUrl,
+} from '$src/utils/workspaceFileUrls.ts'
 import { AiPromptInputController } from '$src/services/ai-prompt-input-controller.ts'
 import MediaLibraryService from '$src/services/media-library-service.ts'
 import { describeMedia, describeText } from '$src/services/media-descriptor-service.ts'
@@ -1257,15 +1263,13 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
                 const node = currentCanvasState?.nodes.find((candidate: CanvasNode) => candidate.nodeId === nodeId)
                 if (!node) return
 
-                // Uploaded documents/audio live under the unified /api/files route;
-                // download via a tokenized attachment link (the route honors
-                // ?download=true). Image/video keep their existing path below.
+                // Uploaded documents/audio use a tokenized attachment link.
                 if (node.type === 'mediaDocument' || node.type === 'audio') {
                     void (async () => {
                         const API_BASE_URL = import.meta.env.VITE_API_URL || ''
                         const token = await AuthService.getTokenSilently()
                         if (!token) return
-                        const href = `${API_BASE_URL}/api/files/${workspaceId}/${node.fileId}?download=true&token=${encodeURIComponent(token)}`
+                        const href = `${API_BASE_URL}${buildWorkspaceFilePath(workspaceId, node.fileId)}?download=true&token=${encodeURIComponent(token)}`
                         const a = document.createElement('a')
                         a.href = href
                         a.rel = 'noopener'
@@ -1282,10 +1286,9 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
                 void (async () => {
                     const API_BASE_URL = import.meta.env.VITE_API_URL || ''
                     const token = await AuthService.getTokenSilently()
-                    const strippedSrc = node.src.replace(/[?&]token=[^&]+/, '')
-                    const route = node.type === 'video' ? 'videos' : 'images'
-                    const isStoredMedia = strippedSrc.startsWith('/api/') || (strippedSrc.startsWith('http') && strippedSrc.includes(`/api/${route}/`))
-                    const resolvedSrc = isStoredMedia ? `/api/${route}/${workspaceId}/${node.fileId}` : strippedSrc
+                    const resolvedSrc = node.fileId
+                        ? buildWorkspaceFilePath(node.workspaceId || workspaceId, node.fileId)
+                        : node.src
                     const mediaSrc = buildImageSrc(resolvedSrc, API_BASE_URL, token || false)
                     await downloadImage(mediaSrc, {
                         getAuthToken: async () => {
@@ -1314,8 +1317,7 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
                     const formData = new FormData()
                     formData.append('file', file)
 
-                    const route = node.type === 'video' ? 'videos' : 'images'
-                    const response = await fetch(`${API_BASE_URL}/api/${route}/${workspaceId}`, {
+                    const response = await fetch(`${API_BASE_URL}${buildWorkspaceFilesPath(workspaceId)}`, {
                         method: 'POST',
                         headers: { 'Authorization': `Bearer ${token}` },
                         body: formData
@@ -10190,16 +10192,16 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
     }
 
     function buildImageSrc(imageUrl: string, apiBaseUrl: string, token: string | false): string {
-        if (!imageUrl) return 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII='
-        if (imageUrl.startsWith('data:')) return imageUrl
-        if (imageUrl.startsWith('/api/')) return `${apiBaseUrl}${imageUrl}${token ? `?token=${token}` : ''}`
-        if (imageUrl.startsWith('http') && imageUrl.includes('/api/files/')) return `${imageUrl}${token ? `?token=${token}` : ''}`
-        if (imageUrl.startsWith('http')) return imageUrl
-        return `data:image/png;base64,${imageUrl}`
+        return resolveMediaUrl(imageUrl, {
+            apiBaseUrl,
+            base64MimeType: 'image/png',
+            emptyFallback: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=',
+            token,
+        })
     }
 
     function buildStoredImageSrc(workspaceId: string, fileId: string): string {
-        return `/api/files/${encodeURIComponent(workspaceId)}/${encodeURIComponent(fileId)}`
+        return buildWorkspaceFilePath(workspaceId, fileId)
     }
 
     function buildGeneratedImageFrameSrc({
@@ -10213,7 +10215,9 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
         fileId?: string
         fallbackSrc?: string
     }): string {
-        if (imageUrl?.trim()) return buildImageSrc(imageUrl, '', false)
+        const trimmedImageUrl = imageUrl?.trim()
+        if (fileId && (!trimmedImageUrl || isWorkspaceFileEndpoint(trimmedImageUrl))) return buildStoredImageSrc(imageWorkspaceId, fileId)
+        if (trimmedImageUrl) return buildImageSrc(trimmedImageUrl, '', false)
         if (fileId) return buildStoredImageSrc(imageWorkspaceId, fileId)
         if (fallbackSrc) return fallbackSrc
         return buildImageSrc('', '', false)

--- a/services/web-ui/src/infographics/workspace/extractionTab.ts
+++ b/services/web-ui/src/infographics/workspace/extractionTab.ts
@@ -11,11 +11,12 @@ import {
     type SubstepView,
 } from '$src/infographics/workspace/extractionTimelineModel.ts'
 import { MarkdownStreamRenderer, renderMarkdownStatic } from '$src/utils/markdownStreamRenderer.ts'
+import { resolveMediaUrl } from '$src/utils/workspaceFileUrls.ts'
 
 const API_BASE_URL = (import.meta.env.VITE_API_URL || '').replace(/\/$/, '')
 
 const withApiBaseUrl = (url: string): string =>
-    url.startsWith('/api/') ? `${API_BASE_URL}${url}` : url
+    resolveMediaUrl(url, { apiBaseUrl: API_BASE_URL })
 
 export type ExtractionTabContext = {
     imageNatsUrl?: string
@@ -147,10 +148,7 @@ function buildPhaseTimeline(phases: PhaseView[], containerEl: HTMLElement, isLiv
 }
 
 function appendImageAuth(url: string, accessToken = ''): string {
-    const apiUrl = withApiBaseUrl(url)
-    if (!accessToken) return apiUrl
-    const separator = apiUrl.includes('?') ? '&' : '?'
-    return `${apiUrl}${separator}${new URLSearchParams({ token: accessToken }).toString()}`
+    return resolveMediaUrl(url, { apiBaseUrl: API_BASE_URL, token: accessToken })
 }
 
 function getFeatureSampleUrl(feature: any, sample: any, accessToken = '', workspaceId = ''): string {

--- a/services/web-ui/src/infographics/workspace/mediaLibraryPanel.ts
+++ b/services/web-ui/src/infographics/workspace/mediaLibraryPanel.ts
@@ -19,6 +19,7 @@ import MediaLibraryService from '$src/services/media-library-service.ts'
 import { organizationStore } from '$src/stores/organizationStore.ts'
 import { userStore } from '$src/stores/userStore.ts'
 import { renderExtractionTabBody } from '$src/infographics/workspace/extractionTab.ts'
+import { resolveMediaUrl } from '$src/utils/workspaceFileUrls.ts'
 
 // Features are org-wide — a single scope. 'shared' (external sharing) is deferred.
 const FEATURE_SCOPES: Array<{ key: string; label: string }> = [
@@ -141,7 +142,7 @@ const HEX_COLOR_PATTERN = /^#[0-9a-f]{6}$/i
 const API_BASE_URL = (import.meta.env.VITE_API_URL || '').replace(/\/$/, '')
 
 const withApiBaseUrl = (url: string): string =>
-    url.startsWith('/api/') ? `${API_BASE_URL}${url}` : url
+    resolveMediaUrl(url, { apiBaseUrl: API_BASE_URL })
 
 const textValue = (value: unknown): string | undefined => {
     if (value === undefined || value === null) return undefined
@@ -323,10 +324,7 @@ export function createMediaLibraryPanel(options: MediaLibraryPanelOptions): Medi
     }
 
     function appendImageAuth(url: string): string {
-        const apiUrl = withApiBaseUrl(url)
-        if (!accessToken) return apiUrl
-        const separator = apiUrl.includes('?') ? '&' : '?'
-        return `${apiUrl}${separator}${new URLSearchParams({ token: accessToken }).toString()}`
+        return resolveMediaUrl(url, { apiBaseUrl: API_BASE_URL, token: accessToken })
     }
 
     function getStoredSampleUrl(feature: FeatureMeta, sampleIndex: number): string {

--- a/services/web-ui/src/infographics/workspace/pixiMediaLayerLogic.ts
+++ b/services/web-ui/src/infographics/workspace/pixiMediaLayerLogic.ts
@@ -3,6 +3,12 @@ import type {
     CanvasViewport,
     ImageCanvasNode,
 } from '@lixpi/constants'
+import {
+    buildWorkspaceFilePath,
+    isApiEndpoint,
+    resolveMediaUrl,
+    stripAuthTokenFromUrl,
+} from '$src/utils/workspaceFileUrls.ts'
 
 export type IndexedImage = {
     minX: number
@@ -85,22 +91,19 @@ export type PixiRendererHealth = 'initializing' | 'ready' | 'destroyed'
 export const transparentPixel = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII='
 
 export function buildPixiImageSrc(imageUrl: string, apiBaseUrl: string, token: string | false): string {
-    if (!imageUrl) return transparentPixel
-    if (imageUrl.startsWith('data:')) return imageUrl
-    if (imageUrl.startsWith('/api/')) return `${apiBaseUrl}${imageUrl}${token ? `?token=${token}` : ''}`
-    return imageUrl
+    return resolveMediaUrl(imageUrl, { apiBaseUrl, emptyFallback: transparentPixel, token })
 }
 
 export function isStoredImageSrc(src: string): boolean {
-    const stripped = src.replace(/[?&]token=[^&]+/, '')
-    return stripped.startsWith('/api/') || (stripped.startsWith('http') && stripped.includes('/api/files/'))
+    const stripped = stripAuthTokenFromUrl(src)
+    return isApiEndpoint(stripped)
 }
 
 export function resolveStoredImagePath(node: ImageCanvasNode, workspaceId: string): string {
-    const strippedSrc = node.src.replace(/[?&]token=[^&]+/, '')
+    const strippedSrc = stripAuthTokenFromUrl(node.src)
     return isStoredImageSrc(strippedSrc)
-        ? `/api/files/${workspaceId}/${node.fileId}`
-        : strippedSrc
+        ? buildWorkspaceFilePath(workspaceId, node.fileId)
+        : resolveMediaUrl(strippedSrc)
 }
 
 export function getPixiLodTier(zoom: number): LodTier {

--- a/services/web-ui/src/infographics/workspace/rendering/audioNodeHandler.ts
+++ b/services/web-ui/src/infographics/workspace/rendering/audioNodeHandler.ts
@@ -5,6 +5,7 @@ import type { CanvasNode, CanvasState, AudioCanvasNode } from '@lixpi/constants'
 import AuthService from '$src/services/auth-service.ts'
 import { settings } from '$src/settings.ts'
 import { html, applyStyle } from '$src/utils/domTemplates.ts'
+import { resolveAuthenticatedMediaUrl } from '$src/utils/workspaceFileUrls.ts'
 
 import type { MediaNodeHandler } from '$src/infographics/workspace/rendering/mediaNodeRegistry.ts'
 import type { WorldPosition } from '$src/infographics/workspace/pixiMediaLayerLogic.ts'
@@ -65,14 +66,10 @@ export function createAudioNodeHandler(options: AudioNodeHandlerOptions): AudioN
     }
 
     const buildAuthenticatedUrl = async (url: string): Promise<string> => {
-        if (!url) return ''
-        if (url.startsWith('data:') || url.startsWith('blob:')) return url
-        if (url.startsWith('/api/')) {
-            const token = await AuthService.getTokenSilently()
-            const API_BASE_URL = import.meta.env.VITE_API_URL || ''
-            return `${API_BASE_URL}${url}${token ? `?token=${token}` : ''}`
-        }
-        return url
+        return resolveAuthenticatedMediaUrl(url, {
+            apiBaseUrl: import.meta.env.VITE_API_URL || '',
+            getAuthToken: () => AuthService.getTokenSilently(),
+        })
     }
 
     const getBorderRadius = (w: number, h: number): number => {

--- a/services/web-ui/src/infographics/workspace/rendering/documentNodeHandler.ts
+++ b/services/web-ui/src/infographics/workspace/rendering/documentNodeHandler.ts
@@ -5,6 +5,7 @@ import type { CanvasNode, CanvasState, DocumentMediaCanvasNode } from '@lixpi/co
 import AuthService from '$src/services/auth-service.ts'
 import { settings } from '$src/settings.ts'
 import { decodeImageInWorker } from '$src/infographics/workspace/pixiImageDecoder.ts'
+import { resolveAuthenticatedMediaUrl } from '$src/utils/workspaceFileUrls.ts'
 
 import type { MediaNodeHandler } from '$src/infographics/workspace/rendering/mediaNodeRegistry.ts'
 import type { WorldPosition } from '$src/infographics/workspace/pixiMediaLayerLogic.ts'
@@ -37,14 +38,10 @@ export function createDocumentNodeHandler(options: DocumentNodeHandlerOptions): 
     const canHandle = (node: CanvasNode): node is DocumentMediaCanvasNode => node.type === 'mediaDocument'
 
     const buildAuthenticatedUrl = async (url: string): Promise<string> => {
-        if (!url) return ''
-        if (url.startsWith('data:') || url.startsWith('blob:')) return url
-        if (url.startsWith('/api/')) {
-            const token = await AuthService.getTokenSilently()
-            const API_BASE_URL = import.meta.env.VITE_API_URL || ''
-            return `${API_BASE_URL}${url}${token ? `?token=${token}` : ''}`
-        }
-        return url
+        return resolveAuthenticatedMediaUrl(url, {
+            apiBaseUrl: import.meta.env.VITE_API_URL || '',
+            getAuthToken: () => AuthService.getTokenSilently(),
+        })
     }
 
     const getBorderRadius = (w: number, h: number): number => {

--- a/services/web-ui/src/infographics/workspace/rendering/videoNodeHandler.ts
+++ b/services/web-ui/src/infographics/workspace/rendering/videoNodeHandler.ts
@@ -6,6 +6,7 @@ import AuthService from '$src/services/auth-service.ts'
 import { settings } from '$src/settings.ts'
 import { decodeImageInWorker } from '$src/infographics/workspace/pixiImageDecoder.ts'
 import { html, applyStyle } from '$src/utils/domTemplates.ts'
+import { resolveAuthenticatedMediaUrl } from '$src/utils/workspaceFileUrls.ts'
 
 import type { MediaNodeHandler } from '$src/infographics/workspace/rendering/mediaNodeRegistry.ts'
 import type { WorldPosition } from '$src/infographics/workspace/pixiMediaLayerLogic.ts'
@@ -72,22 +73,10 @@ export function createVideoNodeHandler(options: VideoNodeHandlerOptions): VideoN
     }
 
     const buildAuthenticatedUrl = async (url: string): Promise<string> => {
-        if (!url) return ''
-        if (url.startsWith('data:') || url.startsWith('blob:')) return url
-        if (url.startsWith('/api/')) {
-            const token = await AuthService.getTokenSilently()
-            const API_BASE_URL = import.meta.env.VITE_API_URL || ''
-            return `${API_BASE_URL}${url}${token ? `?token=${token}` : ''}`
-        }
-        if (url.startsWith('http')) {
-            const stripped = url.replace(/[?&]token=[^&]+/, '')
-            if (stripped.includes('/api/files/')) {
-                const token = await AuthService.getTokenSilently()
-                return `${stripped}${token ? `?token=${token}` : ''}`
-            }
-            return url
-        }
-        return url
+        return resolveAuthenticatedMediaUrl(url, {
+            apiBaseUrl: import.meta.env.VITE_API_URL || '',
+            getAuthToken: () => AuthService.getTokenSilently(),
+        })
     }
 
     const getBorderRadius = (w: number, h: number): number => {

--- a/services/web-ui/src/infographics/workspace/workspace-canvas.test.ts
+++ b/services/web-ui/src/infographics/workspace/workspace-canvas.test.ts
@@ -2437,16 +2437,17 @@ describe('Image loading — PIXI ownership and URL resolution strategy', () => {
 	})
 
 	it('PIXI uses canonical workspaceId path for stored API images', () => {
-		expectSourceToContain(pixiLogicTs, '`/api/files/${workspaceId}/${node.fileId}`')
+		expectSourceToContain(pixiLogicTs, 'buildWorkspaceFilePath(workspaceId, node.fileId)')
 		expectSourceToContain(pixiLogicTs, 'isStoredImageSrc(strippedSrc)')
 	})
 
 	it('PIXI strips stale tokens from node sources before resolving them', () => {
-		expect(pixiLogicTs).toMatch(/node\.src\.replace\([^)]*token[^)]*\)/)
+		expectSourceToContain(pixiLogicTs, 'const strippedSrc = stripAuthTokenFromUrl(node.src)')
+		expectSourceToContain(pixiLogicTs, 'return isStoredImageSrc(strippedSrc)')
 	})
 
 	it('PIXI passes through data and external sources without DOM loading', () => {
-		expectSourceToContain(pixiLogicTs, "if (imageUrl.startsWith('data:')) return imageUrl")
+		expectSourceToContain(pixiLogicTs, 'resolveMediaUrl(strippedSrc)')
 		expectSourceToContain(pixiLayerTs, 'const resolvedSrc = resolveStoredImagePath(node, workspaceId)')
 	})
 
@@ -2507,22 +2508,27 @@ describe('Image generation error cleanup', () => {
 
 describe('buildImageSrc — URL construction logic', () => {
 	const ts = loadTs()
+	const buildImageSrcFn = extractFunctionBody(ts, 'buildImageSrc')
 
 	it('returns transparent pixel for empty imageUrl', () => {
-		expect(ts).toMatch(/if\s*\(\s*!imageUrl\s*\)\s*return\s*['"]data:image\/png;base64,/)
+		expect(buildImageSrcFn).not.toBe('')
+		expectExcerptToContain(buildImageSrcFn, "base64MimeType: 'image/png'")
+		expectExcerptToContain(
+			buildImageSrcFn,
+			'emptyFallback: \'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=\'',
+		)
 	})
 
 	it('returns data: URLs unchanged', () => {
-		expect(ts).toMatch(/if\s*\(\s*imageUrl\.startsWith\(\s*['"]data:['"]\s*\)\s*\)\s*return\s+imageUrl/)
+		expectExcerptToContain(buildImageSrcFn, 'return resolveMediaUrl(imageUrl, {')
 	})
 
 	it('prepends apiBaseUrl for /api/ paths', () => {
-		expect(ts).toMatch(/if\s*\(\s*imageUrl\.startsWith\(\s*['"]\/api\/['"]\s*\)/)
-		expectSourceToContain(ts, '`${apiBaseUrl}${imageUrl}')
+		expectExcerptToContain(buildImageSrcFn, 'apiBaseUrl,')
 	})
 
 	it('appends token as query param for API URLs', () => {
-		expectSourceToContain(ts, '`?token=${token}`')
+		expectExcerptToContain(buildImageSrcFn, 'token,')
 	})
 })
 

--- a/services/web-ui/src/utils/downloadImage.test.ts
+++ b/services/web-ui/src/utils/downloadImage.test.ts
@@ -5,14 +5,28 @@ import { downloadImage } from './downloadImage.ts'
 // SETUP
 // =============================================================================
 
+type MockAnchor = {
+    href: string
+    download: string
+    style: { [key: string]: string }
+    click: ReturnType<typeof vi.fn>
+}
+
+type MockIFrame = {
+    style: { [key: string]: string }
+    src: string
+}
+
 let appendChildSpy: ReturnType<typeof vi.spyOn>
 let removeChildSpy: ReturnType<typeof vi.spyOn>
+let createObjectUrlSpy: ReturnType<typeof vi.spyOn>
+let revokeObjectUrlSpy: ReturnType<typeof vi.spyOn>
 
 beforeEach(() => {
     appendChildSpy = vi.spyOn(document.body, 'appendChild').mockImplementation((node) => node)
     removeChildSpy = vi.spyOn(document.body, 'removeChild').mockImplementation((node) => node)
-    vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:http://localhost/fake-blob')
-    vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {})
+    createObjectUrlSpy = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:http://localhost/fake-blob')
+    revokeObjectUrlSpy = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {})
 })
 
 afterEach(() => {
@@ -20,58 +34,84 @@ afterEach(() => {
     vi.useRealTimers()
 })
 
+const createMockAnchor = (): MockAnchor => ({
+    href: '',
+    download: '',
+    style: {},
+    click: vi.fn(),
+})
+
+const createMockIFrame = (): MockIFrame => ({
+    style: {},
+    src: '',
+})
+
 // =============================================================================
 // DATA / BLOB URLs — fetched as blob + anchor download
 // =============================================================================
 
 describe('downloadImage — data: and blob: URLs (fetch path)', () => {
-    it('fetches a data: URL, creates a blob anchor, and clicks it', async () => {
+    it('fetches a data URL, creates a blob anchor, and clicks it', async () => {
         const blob = new Blob(['png-data'], { type: 'image/png' })
         vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(blob, { status: 200 }))
 
-        const clickSpy = vi.fn()
-        vi.spyOn(document, 'createElement').mockReturnValue({ href: '', download: '', style: {}, click: clickSpy } as any)
+        const anchor = createMockAnchor()
+        vi.spyOn(document, 'createElement').mockReturnValue(anchor as unknown as HTMLAnchorElement)
         vi.useFakeTimers()
 
         await downloadImage('data:image/png;base64,iVBORw0KGgo=')
 
         expect(globalThis.fetch).toHaveBeenCalledWith('data:image/png;base64,iVBORw0KGgo=')
-        expect(URL.createObjectURL).toHaveBeenCalled()
-        expect(clickSpy).toHaveBeenCalledOnce()
-        expect(appendChildSpy).toHaveBeenCalled()
+        expect(createObjectUrlSpy).toHaveBeenCalledWith(blob)
+        expect(anchor.click).toHaveBeenCalledOnce()
+        expect(anchor.href).toBe('blob:http://localhost/fake-blob')
+        expect(anchor.download).toBe('image.png')
+        expect(anchor.style.display).toBe('none')
+        expect(appendChildSpy).toHaveBeenCalledWith(anchor)
 
         await vi.advanceTimersByTimeAsync(200)
-        expect(removeChildSpy).toHaveBeenCalled()
-        expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:http://localhost/fake-blob')
+        expect(removeChildSpy).toHaveBeenCalledWith(anchor)
+        expect(revokeObjectUrlSpy).toHaveBeenCalledWith('blob:http://localhost/fake-blob')
     })
 
-    it('uses provided filename for data: URL', async () => {
+    it('uses provided filename for data URL downloads', async () => {
         const blob = new Blob(['data'], { type: 'image/jpeg' })
         vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(blob, { status: 200 }))
 
-        const anchor = { href: '', download: '', style: {}, click: vi.fn() }
-        vi.spyOn(document, 'createElement').mockReturnValue(anchor as any)
+        const anchor = createMockAnchor()
+        vi.spyOn(document, 'createElement').mockReturnValue(anchor as unknown as HTMLAnchorElement)
 
         await downloadImage('data:image/jpeg;base64,/9j/4AAQ', { filename: 'my-photo.jpg' })
 
         expect(anchor.download).toBe('my-photo.jpg')
     })
 
-    it('derives generic filename from blob type for data: URL', async () => {
+    it('derives a generic filename from blob MIME type when URL path has no extension', async () => {
         const blob = new Blob(['data'], { type: 'image/webp' })
         vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(blob, { status: 200 }))
 
-        const anchor = { href: '', download: '', style: {}, click: vi.fn() }
-        vi.spyOn(document, 'createElement').mockReturnValue(anchor as any)
+        const anchor = createMockAnchor()
+        vi.spyOn(document, 'createElement').mockReturnValue(anchor as unknown as HTMLAnchorElement)
 
         await downloadImage('data:image/webp;base64,UklGR')
 
         expect(anchor.download).toBe('image.webp')
     })
 
-    it('falls back to window.open when fetch of data: URL fails', async () => {
+    it('falls back to window.open when fetch returns a non-OK response', async () => {
+        vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('error', { status: 500 }))
+        const windowOpenSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
+
+        await downloadImage('data:image/png;base64,notfound')
+
+        expect(windowOpenSpy).toHaveBeenCalledWith('data:image/png;base64,notfound', '_blank')
+    })
+
+    it('falls back to window.open when fetch of data URL fails', async () => {
         vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('Failed'))
         const windowOpenSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
+        const anchor = createMockAnchor()
+        vi.spyOn(document, 'createElement').mockReturnValue(anchor as unknown as HTMLAnchorElement)
 
         await downloadImage('data:image/png;base64,broken')
 
@@ -82,54 +122,55 @@ describe('downloadImage — data: and blob: URLs (fetch path)', () => {
         const blob = new Blob(['data'], { type: 'image/png' })
         vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(blob, { status: 200 }))
 
-        const clickSpy = vi.fn()
-        vi.spyOn(document, 'createElement').mockReturnValue({ href: '', download: '', style: {}, click: clickSpy } as any)
+        const anchor = createMockAnchor()
+        vi.spyOn(document, 'createElement').mockReturnValue(anchor as unknown as HTMLAnchorElement)
 
         await downloadImage('blob:http://localhost/some-blob-id')
 
-        expect(globalThis.fetch).toHaveBeenCalledWith('blob:http://localhost/some-blob-id')
-        expect(clickSpy).toHaveBeenCalledOnce()
+        expect(anchor.click).toHaveBeenCalledOnce()
+        expect(anchor.href).toBe('blob:http://localhost/fake-blob')
     })
 })
 
 // =============================================================================
-// HTTP URLs — iframe navigation with ?download=true
+// HTTP(S) URLs — iframe navigation with appended download param
 // =============================================================================
 
-describe('downloadImage — HTTP URLs (navigation path)', () => {
-    it('creates a hidden iframe with ?download=true appended', async () => {
-        const iframe = { style: { display: '' }, src: '' }
-        vi.spyOn(document, 'createElement').mockReturnValue(iframe as any)
+describe('downloadImage — HTTP(S) URLs (navigation path)', () => {
+    it('normalizes workspace API URLs, appends ?download=true, and sets iframe styles', async () => {
+        const iframe = createMockIFrame()
+        vi.spyOn(document, 'createElement').mockReturnValue(iframe as unknown as HTMLIFrameElement)
 
         await downloadImage('http://localhost:3005/api/images/ws1/file1?token=abc')
 
         expect(document.createElement).toHaveBeenCalledWith('iframe')
         expect(iframe.style.display).toBe('none')
-        expect(iframe.src).toBe('http://localhost:3005/api/images/ws1/file1?token=abc&download=true')
-        expect(appendChildSpy).toHaveBeenCalled()
+        expect(iframe.src).toBe('http://localhost:3005/api/files/ws1/file1?token=abc&download=true')
+        expect(appendChildSpy).toHaveBeenCalledWith(iframe)
     })
 
     it('appends ?download=true when URL has no query params', async () => {
-        const iframe = { style: { display: '' }, src: '' }
-        vi.spyOn(document, 'createElement').mockReturnValue(iframe as any)
+        const iframe = createMockIFrame()
+        vi.spyOn(document, 'createElement').mockReturnValue(iframe as unknown as HTMLIFrameElement)
 
         await downloadImage('http://localhost:3005/api/images/ws1/file1')
 
-        expect(iframe.src).toBe('http://localhost:3005/api/images/ws1/file1?download=true')
+        expect(iframe.src).toBe('http://localhost:3005/api/files/ws1/file1?download=true')
     })
 
     it('does not call fetch for HTTP URLs', async () => {
         const fetchSpy = vi.spyOn(globalThis, 'fetch')
-        vi.spyOn(document, 'createElement').mockReturnValue({ style: {}, src: '' } as any)
+        const iframe = createMockIFrame()
+        vi.spyOn(document, 'createElement').mockReturnValue(iframe as unknown as HTMLIFrameElement)
 
         await downloadImage('http://localhost:3005/api/images/ws1/file1?token=abc')
 
         expect(fetchSpy).not.toHaveBeenCalled()
     })
 
-    it('cleans up iframe after timeout', async () => {
-        const iframe = { style: { display: '' }, src: '' }
-        vi.spyOn(document, 'createElement').mockReturnValue(iframe as any)
+    it('removes the iframe after the cleanup timeout', async () => {
+        const iframe = createMockIFrame()
+        vi.spyOn(document, 'createElement').mockReturnValue(iframe as unknown as HTMLIFrameElement)
         vi.useFakeTimers()
 
         await downloadImage('http://localhost:3005/api/images/ws1/file1')
@@ -145,10 +186,10 @@ describe('downloadImage — HTTP URLs (navigation path)', () => {
 // AUTH TOKEN REFRESH
 // =============================================================================
 
-describe('downloadImage — getAuthToken refreshes stale tokens', () => {
+describe('downloadImage — getAuthToken', () => {
     it('replaces stale token= param with fresh token from getAuthToken', async () => {
-        const iframe = { style: { display: '' }, src: '' }
-        vi.spyOn(document, 'createElement').mockReturnValue(iframe as any)
+        const iframe = createMockIFrame()
+        vi.spyOn(document, 'createElement').mockReturnValue(iframe as unknown as HTMLIFrameElement)
 
         const getAuthToken = vi.fn().mockResolvedValue('fresh-jwt-token')
 
@@ -159,34 +200,30 @@ describe('downloadImage — getAuthToken refreshes stale tokens', () => {
 
         expect(getAuthToken).toHaveBeenCalledOnce()
         expect(iframe.src).toBe(
-            'http://localhost:3005/api/images/ws1/file1?token=fresh-jwt-token&download=true'
+            'http://localhost:3005/api/files/ws1/file1?token=fresh-jwt-token&download=true',
         )
     })
 
-    it('does not call getAuthToken when URL has no token= param', async () => {
-        const iframe = { style: { display: '' }, src: '' }
-        vi.spyOn(document, 'createElement').mockReturnValue(iframe as any)
+    it('calls getAuthToken for API URLs even when token is missing', async () => {
+        const iframe = createMockIFrame()
+        vi.spyOn(document, 'createElement').mockReturnValue(iframe as unknown as HTMLIFrameElement)
 
         const getAuthToken = vi.fn().mockResolvedValue('fresh-jwt-token')
 
-        await downloadImage(
-            'http://localhost:3005/api/images/ws1/file1',
-            { getAuthToken },
-        )
+        await downloadImage('http://localhost:3005/api/images/ws1/file1', { getAuthToken })
 
-        expect(getAuthToken).not.toHaveBeenCalled()
-        expect(iframe.src).toBe('http://localhost:3005/api/images/ws1/file1?download=true')
+        expect(getAuthToken).toHaveBeenCalledOnce()
+        expect(iframe.src).toBe('http://localhost:3005/api/files/ws1/file1?token=fresh-jwt-token&download=true')
     })
 
-    it('does not call getAuthToken for data: URLs', async () => {
-        const blob = new Blob(['data'], { type: 'image/png' })
-        vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(blob, { status: 200 }))
-        vi.spyOn(document, 'createElement').mockReturnValue({ href: '', download: '', style: {}, click: vi.fn() } as any)
-
+    it('passes absolute non-API URLs through without refreshing token', async () => {
+        const iframe = createMockIFrame()
+        vi.spyOn(document, 'createElement').mockReturnValue(iframe as unknown as HTMLIFrameElement)
         const getAuthToken = vi.fn().mockResolvedValue('fresh-jwt-token')
 
-        await downloadImage('data:image/png;base64,iVBORw0KGgo=', { getAuthToken })
+        await downloadImage('https://cdn.example.com/images/file1.png', { getAuthToken })
 
         expect(getAuthToken).not.toHaveBeenCalled()
+        expect(iframe.src).toBe('https://cdn.example.com/images/file1.png?download=true')
     })
 })

--- a/services/web-ui/src/utils/downloadImage.ts
+++ b/services/web-ui/src/utils/downloadImage.ts
@@ -11,13 +11,17 @@
 //                        which triggers the browser's native save dialog.
 //                        This avoids cross-origin fetch issues entirely.
 //
-// When a getAuthToken callback is provided, any existing ?token= query param
-// in the URL is replaced with a freshly obtained token. This prevents 401
-// errors from expired JWTs that were baked into the URL at creation time
-// (e.g. canvas image nodes).
+// When a getAuthToken callback is provided, API media URLs get a freshly
+// obtained token. This prevents 401 errors from expired JWTs that were baked
+// into stored canvas media URLs.
 // =============================================================================
 
 import { applyStyle } from '$src/utils/domTemplates.ts'
+import {
+    isApiEndpoint,
+    normalizeWorkspaceFileEndpoint,
+    resolveApiMediaUrl,
+} from '$src/utils/workspaceFileUrls.ts'
 
 type DownloadImageOptions = {
     filename?: string
@@ -58,14 +62,6 @@ function appendDownloadParam(url: string): string {
     return `${url}${separator}download=true`
 }
 
-function replaceTokenInUrl(url: string, freshToken: string): string {
-    // Replace existing token= param with a fresh one
-    return url.replace(
-        /([?&])token=[^&]*/,
-        `$1token=${encodeURIComponent(freshToken)}`
-    )
-}
-
 async function downloadViaFetch(imageUrl: string, filename?: string): Promise<void> {
     const response = await fetch(imageUrl)
     if (!response.ok) throw new Error(`Fetch failed: ${response.status}`)
@@ -89,12 +85,12 @@ async function downloadViaFetch(imageUrl: string, filename?: string): Promise<vo
 }
 
 async function downloadViaNavigation(imageUrl: string, getAuthToken?: () => Promise<string>): Promise<void> {
-    let url = imageUrl
+    let url = normalizeWorkspaceFileEndpoint(imageUrl)
 
-    // Refresh stale auth token if a token refresher is provided
-    if (getAuthToken && url.includes('token=')) {
+    // Refresh stale auth token if a token refresher is provided.
+    if (getAuthToken && isApiEndpoint(url)) {
         const freshToken = await getAuthToken()
-        url = replaceTokenInUrl(url, freshToken)
+        url = resolveApiMediaUrl(url, { token: freshToken })
     }
 
     const downloadUrl = appendDownloadParam(url)

--- a/services/web-ui/src/utils/workspaceFileUrls.test.ts
+++ b/services/web-ui/src/utils/workspaceFileUrls.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import {
+    buildWorkspaceFilePath,
+    buildWorkspaceFilesPath,
+    isWorkspaceFileEndpoint,
+    isApiEndpoint,
+    normalizeWorkspaceFileEndpoint,
+    resolveApiMediaUrl,
+    resolveMediaUrl,
+    resolveAuthenticatedMediaUrl,
+    setAuthTokenOnUrl,
+    stripAuthTokenFromUrl,
+} from './workspaceFileUrls.ts'
+
+// =============================================================================
+// BUILD / ID HELPERS
+// =============================================================================
+
+describe('workspaceFileUrls build helpers', () => {
+    it('builds encoded workspace file and collection paths', () => {
+        expect(buildWorkspaceFilePath('my workspace', 'my file')).toBe('/api/files/my%20workspace/my%20file')
+        expect(buildWorkspaceFilesPath('my workspace')).toBe('/api/files/my%20workspace')
+    })
+})
+
+// =============================================================================
+// PATH DETECTION
+// =============================================================================
+
+describe('workspaceFileUrls detection', () => {
+    it('identifies workspace file endpoints from absolute and relative URLs', () => {
+        expect(isWorkspaceFileEndpoint('https://cdn.local/api/files/ws1/file1')).toBe(true)
+        expect(isWorkspaceFileEndpoint('/api/files/ws1/file1')).toBe(true)
+        expect(isWorkspaceFileEndpoint('/api/images/ws1/file1')).toBe(true)
+        expect(isWorkspaceFileEndpoint('/api/videos/ws1/file1')).toBe(true)
+        expect(isWorkspaceFileEndpoint('https://cdn.local/api/other/ws1/file1')).toBe(false)
+        expect(isWorkspaceFileEndpoint('https://cdn.local/assets/ws1/file1')).toBe(false)
+    })
+
+    it('identifies API endpoints from absolute and relative paths', () => {
+        expect(isApiEndpoint('https://cdn.local/api/files/ws1/file1')).toBe(true)
+        expect(isApiEndpoint('/api/images/ws1/file1')).toBe(true)
+        expect(isApiEndpoint('ws://cdn.local/api/files/ws1/file1')).toBe(true)
+    })
+})
+
+// =============================================================================
+// NORMALIZATION
+// =============================================================================
+
+describe('workspaceFileUrls normalization', () => {
+    it('normalizes /api/images and /api/videos endpoints to /api/files', () => {
+        expect(normalizeWorkspaceFileEndpoint('https://cdn.local/api/images/ws1/file1?token=abc')).toBe(
+            'https://cdn.local/api/files/ws1/file1?token=abc',
+        )
+        expect(normalizeWorkspaceFileEndpoint('http://localhost/api/videos/ws1/file1#thumb')).toBe(
+            'http://localhost/api/files/ws1/file1#thumb',
+        )
+    })
+
+    it('normalizes relative endpoints to /api/files and preserves query params', () => {
+        expect(normalizeWorkspaceFileEndpoint('/api/images/ws1/file1?download=true')).toBe(
+            '/api/files/ws1/file1?download=true',
+        )
+    })
+
+    it('leaves non-workspace endpoints untouched', () => {
+        expect(normalizeWorkspaceFileEndpoint('/api/other/ws1/file1')).toBe('/api/other/ws1/file1')
+        expect(normalizeWorkspaceFileEndpoint('/assets/ws1/file1')).toBe('/assets/ws1/file1')
+        expect(normalizeWorkspaceFileEndpoint('/api/files/ws1')).toBe('/api/files/ws1')
+    })
+})
+
+// =============================================================================
+// TOKEN MANIPULATION
+// =============================================================================
+
+describe('workspaceFileUrls token helpers', () => {
+    it('strips token params from URLs while preserving other query values', () => {
+        expect(stripAuthTokenFromUrl('https://cdn.local/api/files/ws1/file1?download=true&token=abc&rev=1')).toBe(
+            'https://cdn.local/api/files/ws1/file1?download=true&rev=1',
+        )
+        expect(stripAuthTokenFromUrl('/api/files/ws1/file1?download=true&token=abc&rev=1')).toBe(
+            '/api/files/ws1/file1?download=true&rev=1',
+        )
+        expect(stripAuthTokenFromUrl('https://cdn.local/api/files/ws1/file1?token=abc')).toBe(
+            'https://cdn.local/api/files/ws1/file1',
+        )
+    })
+
+    it('adds or replaces token parameters', () => {
+        expect(setAuthTokenOnUrl('https://cdn.local/api/files/ws1/file1?download=true', 'tok')).toBe(
+            'https://cdn.local/api/files/ws1/file1?download=true&token=tok',
+        )
+        expect(setAuthTokenOnUrl('https://cdn.local/api/files/ws1/file1?token=old', 'new')).toBe(
+            'https://cdn.local/api/files/ws1/file1?token=new',
+        )
+        expect(setAuthTokenOnUrl('/api/files/ws1/file1?download=true', 'tok')).toBe(
+            '/api/files/ws1/file1?download=true&token=tok',
+        )
+        expect(setAuthTokenOnUrl('/api/files/ws1/file1', '')).toBe('/api/files/ws1/file1')
+    })
+})
+
+// =============================================================================
+// MEDIA URL RESOLUTION
+// =============================================================================
+
+describe('workspaceFileUrls API resolution', () => {
+    it('resolves relative workspace paths against API base URL and injects token', () => {
+        expect(resolveApiMediaUrl('/api/images/ws1/file1')).toBe('/api/files/ws1/file1')
+        expect(resolveApiMediaUrl('/api/images/ws1/file1', { apiBaseUrl: 'https://api.example.test/' })).toBe(
+            'https://api.example.test/api/files/ws1/file1',
+        )
+        expect(resolveApiMediaUrl('/api/images/ws1/file1', { apiBaseUrl: 'https://api.example.test', token: 'fresh' })).toBe(
+            'https://api.example.test/api/files/ws1/file1?token=fresh',
+        )
+    })
+
+    it('replaces existing token params on absolute API URLs', () => {
+        expect(
+            resolveApiMediaUrl('http://localhost:3005/api/images/ws1/file1?token=stale&download=true', { token: 'fresh' }),
+        ).toBe(
+            'http://localhost:3005/api/files/ws1/file1?download=true&token=fresh',
+        )
+    })
+
+    it('leaves non-API URLs untouched', () => {
+        expect(resolveApiMediaUrl('https://cdn.example.com/assets/file1.png')).toBe('https://cdn.example.com/assets/file1.png')
+        expect(resolveApiMediaUrl('s3://bucket/object')).toBe('s3://bucket/object')
+    })
+})
+
+describe('workspaceFileUrls media resolution', () => {
+    it('resolves data and blob URLs without changes', () => {
+        expect(resolveMediaUrl('data:image/png;base64,abc')).toBe('data:image/png;base64,abc')
+        expect(resolveMediaUrl('blob:http://localhost/fake')).toBe('blob:http://localhost/fake')
+    })
+
+    it('returns fallback for empty URLs', () => {
+        expect(resolveMediaUrl('')).toBe('')
+        expect(resolveMediaUrl('', { emptyFallback: 'fallback' })).toBe('fallback')
+    })
+
+    it('wraps non-browser-addressable URLs in a base64 data URI when requested', () => {
+        expect(resolveMediaUrl('s3://bucket/object', { base64MimeType: 'image/png' })).toBe(
+            'data:image/png;base64,s3://bucket/object',
+        )
+        expect(resolveMediaUrl('assets/path/file', { base64MimeType: 'image/png' })).toBe(
+            'data:image/png;base64,assets/path/file',
+        )
+    })
+})
+
+describe('workspaceFileUrls authenticated resolution', () => {
+    beforeEach(() => {
+        vi.useRealTimers()
+    })
+
+    afterEach(() => {
+        vi.restoreAllMocks()
+    })
+
+    it('returns existing values for data and blob URLs', async () => {
+        const resultData = await resolveAuthenticatedMediaUrl('data:image/png;base64,abc')
+        expect(resultData).toBe('data:image/png;base64,abc')
+
+        const resultBlob = await resolveAuthenticatedMediaUrl('blob:http://localhost/fake')
+        expect(resultBlob).toBe('blob:http://localhost/fake')
+    })
+
+    it('calls getAuthToken for API endpoints and injects refreshed token', async () => {
+        const getAuthToken = vi.fn().mockResolvedValue('fresh-token')
+
+        const result = await resolveAuthenticatedMediaUrl('http://localhost:3005/api/images/ws1/file1', { getAuthToken })
+
+        expect(getAuthToken).toHaveBeenCalledOnce()
+        expect(result).toBe('http://localhost:3005/api/files/ws1/file1?token=fresh-token')
+    })
+
+    it('does not call getAuthToken for non-API URLs', async () => {
+        const getAuthToken = vi.fn().mockResolvedValue('fresh-token')
+        const result = await resolveAuthenticatedMediaUrl('https://cdn.example.com/file.png', { getAuthToken })
+
+        expect(getAuthToken).not.toHaveBeenCalled()
+        expect(result).toBe('https://cdn.example.com/file.png')
+    })
+
+    it('uses provided token in preference to getAuthToken', async () => {
+        const getAuthToken = vi.fn().mockResolvedValue('fresh-token')
+
+        const result = await resolveAuthenticatedMediaUrl('http://localhost:3005/api/images/ws1/file1?token=stale', {
+            token: 'provided',
+            getAuthToken,
+        })
+
+        expect(getAuthToken).not.toHaveBeenCalled()
+        expect(result).toBe('http://localhost:3005/api/files/ws1/file1?token=provided')
+    })
+
+    it('returns empty fallback when URL is empty', async () => {
+        expect(await resolveAuthenticatedMediaUrl('', { emptyFallback: 'empty' })).toBe('empty')
+    })
+
+    it('propagates token retrieval failures', async () => {
+        const error = new Error('token failed')
+        const getAuthToken = vi.fn().mockRejectedValue(error)
+
+        await expect(
+            resolveAuthenticatedMediaUrl('http://localhost:3005/api/images/ws1/file1', { getAuthToken }),
+        ).rejects.toThrow(error)
+    })
+})

--- a/services/web-ui/src/utils/workspaceFileUrls.ts
+++ b/services/web-ui/src/utils/workspaceFileUrls.ts
@@ -1,0 +1,153 @@
+const ABSOLUTE_URL_PATTERN = /^[a-z][a-z0-9+.-]*:\/\//i
+const WORKSPACE_FILE_ENDPOINT_PATTERN = /^\/api\/(?:files|images|videos)\/([^/]+)\/([^/]+)$/
+const WORKSPACE_FILE_ENDPOINT_PREFIX_PATTERN = /^\/api\/(?:files|images|videos)\//
+
+export type WorkspaceFileToken = string | false | null | undefined
+
+export type ResolveMediaUrlOptions = {
+    apiBaseUrl?: string
+    base64MimeType?: string
+    emptyFallback?: string
+    token?: WorkspaceFileToken
+}
+
+export type ResolveAuthenticatedMediaUrlOptions = ResolveMediaUrlOptions & {
+    getAuthToken?: () => Promise<WorkspaceFileToken>
+}
+
+function getUrlBase(): string {
+    return typeof window === 'undefined' ? 'http://localhost' : window.location.origin
+}
+
+function parseUrl(url: string): { parsed: URL; isAbsolute: boolean } | null {
+    try {
+        const isAbsolute = ABSOLUTE_URL_PATTERN.test(url)
+        return {
+            parsed: isAbsolute ? new URL(url) : new URL(url, getUrlBase()),
+            isAbsolute,
+        }
+    } catch {
+        return null
+    }
+}
+
+function stringifyUrl(parsed: URL, isAbsolute: boolean): string {
+    if (isAbsolute) return parsed.toString()
+    return `${parsed.pathname}${parsed.search}${parsed.hash}`
+}
+
+function normalizeApiBaseUrl(apiBaseUrl = ''): string {
+    return apiBaseUrl.replace(/\/$/, '')
+}
+
+function isBrowserAddressableUrl(url: string): boolean {
+    return url.startsWith('data:') ||
+        url.startsWith('blob:') ||
+        url.startsWith('/api/') ||
+        url.startsWith('http')
+}
+
+export function buildWorkspaceFilePath(workspaceId: string, fileId: string): string {
+    return `/api/files/${encodeURIComponent(workspaceId)}/${encodeURIComponent(fileId)}`
+}
+
+export function buildWorkspaceFilesPath(workspaceId: string): string {
+    return `/api/files/${encodeURIComponent(workspaceId)}`
+}
+
+export function isWorkspaceFileEndpoint(url: string): boolean {
+    const result = parseUrl(url)
+    if (!result) return false
+    return WORKSPACE_FILE_ENDPOINT_PREFIX_PATTERN.test(result.parsed.pathname)
+}
+
+export function isApiEndpoint(url: string): boolean {
+    const result = parseUrl(url)
+    if (!result) return false
+    return result.parsed.pathname.startsWith('/api/')
+}
+
+export function normalizeWorkspaceFileEndpoint(url: string): string {
+    const result = parseUrl(url)
+    if (!result) return url
+
+    const match = WORKSPACE_FILE_ENDPOINT_PATTERN.exec(result.parsed.pathname)
+    if (!match) return url
+
+    const [, workspaceId, fileId] = match
+    if (!workspaceId || !fileId) return url
+
+    result.parsed.pathname = buildWorkspaceFilePath(workspaceId, fileId)
+    return stringifyUrl(result.parsed, result.isAbsolute)
+}
+
+export function stripAuthTokenFromUrl(url: string): string {
+    const result = parseUrl(url)
+    if (!result) {
+        return url
+            .replace(/([?&])token=[^&]*/g, '')
+            .replace('?&', '?')
+            .replace(/[?&]$/, '')
+    }
+
+    result.parsed.searchParams.delete('token')
+    return stringifyUrl(result.parsed, result.isAbsolute)
+}
+
+export function setAuthTokenOnUrl(url: string, token: string): string {
+    if (!token) return url
+
+    const result = parseUrl(url)
+    if (!result) {
+        const separator = url.includes('?') ? '&' : '?'
+        return `${url}${separator}token=${encodeURIComponent(token)}`
+    }
+
+    result.parsed.searchParams.set('token', token)
+    return stringifyUrl(result.parsed, result.isAbsolute)
+}
+
+export function resolveApiMediaUrl(url: string, options: ResolveMediaUrlOptions = {}): string {
+    const normalizedUrl = normalizeWorkspaceFileEndpoint(url)
+    const token = options.token || ''
+
+    if (normalizedUrl.startsWith('/api/')) {
+        const apiBaseUrl = normalizeApiBaseUrl(options.apiBaseUrl)
+        const sourceUrl = `${apiBaseUrl}${normalizedUrl}`
+        return token ? setAuthTokenOnUrl(sourceUrl, token) : sourceUrl
+    }
+
+    if (normalizedUrl.startsWith('http') && isApiEndpoint(normalizedUrl)) {
+        const sourceUrl = token ? stripAuthTokenFromUrl(normalizedUrl) : normalizedUrl
+        return token ? setAuthTokenOnUrl(sourceUrl, token) : sourceUrl
+    }
+
+    return normalizedUrl
+}
+
+export function resolveMediaUrl(url: string, options: ResolveMediaUrlOptions = {}): string {
+    if (!url) return options.emptyFallback ?? ''
+    if (url.startsWith('data:') || url.startsWith('blob:')) return url
+
+    const resolvedUrl = resolveApiMediaUrl(url, options)
+    if (isBrowserAddressableUrl(resolvedUrl)) return resolvedUrl
+
+    return options.base64MimeType
+        ? `data:${options.base64MimeType};base64,${resolvedUrl}`
+        : resolvedUrl
+}
+
+export async function resolveAuthenticatedMediaUrl(
+    url: string,
+    options: ResolveAuthenticatedMediaUrlOptions = {},
+): Promise<string> {
+    if (!url) return options.emptyFallback ?? ''
+    if (url.startsWith('data:') || url.startsWith('blob:')) return url
+
+    const normalizedUrl = normalizeWorkspaceFileEndpoint(url)
+    const token = options.token || (isApiEndpoint(normalizedUrl) && options.getAuthToken
+        ? await options.getAuthToken()
+        : '')
+
+    return resolveMediaUrl(normalizedUrl, { ...options, token })
+}


### PR DESCRIPTION
## Summary

- Extracts a shared `workspaceFileUrls.ts` utility that owns building/normalizing workspace file endpoint paths, detecting API vs. external/data/blob URLs, setting/stripping auth tokens, and resolving media URLs (sync and authenticated/async variants).
- Updates the ProseMirror AI-generated image/video nodes, image selection node view, image generation trace details, context preview, download utility, and infographics workspace canvas/media rendering handlers to use the shared helpers instead of duplicated ad-hoc token/URL string manipulation.
- Adds test coverage for the new `workspaceFileUrls` module and updates existing tests for the touched components.

Closes #293