### PR TITLE
LIX-295 # Harden canvas collision resolver and preserve API media lineage across canvas saves

### DIFF
--- a/packages/lixpi/canvas-engine/src/shared/canvas-node/rigid-group-collisions.test.ts
+++ b/packages/lixpi/canvas-engine/src/shared/canvas-node/rigid-group-collisions.test.ts
@@ -22,6 +22,30 @@ function makeImageNode(
     }
 }
 
+function rectsOverlap(
+    a: { x: number; y: number; width: number; height: number },
+    b: { x: number; y: number; width: number; height: number },
+): boolean {
+    return a.x < b.x + b.width
+        && a.x + a.width > b.x
+        && a.y < b.y + b.height
+        && a.y + a.height > b.y
+}
+
+function getGroupRect(nodes: CanvasNode[], nodeIds: string[]): { x: number; y: number; width: number; height: number } {
+    const groupNodes = nodes.filter(node => nodeIds.includes(node.nodeId))
+    const minX = Math.min(...groupNodes.map(node => node.position.x))
+    const minY = Math.min(...groupNodes.map(node => node.position.y))
+    const maxX = Math.max(...groupNodes.map(node => node.position.x + node.dimensions.width))
+    const maxY = Math.max(...groupNodes.map(node => node.position.y + node.dimensions.height))
+    return {
+        x: minX,
+        y: minY,
+        width: maxX - minX,
+        height: maxY - minY,
+    }
+}
+
 // =============================================================================
 // RIGID GROUP COLLISION RESOLUTION
 // =============================================================================
@@ -208,5 +232,46 @@ describe('resolveRigidCanvasNodeGroupCollisions', () => {
         ])
         expect(result.changed).toBe(false)
         expect(result.nodes).toBe(nodes)
+    })
+
+    it('separates overlapping multi-node groups while preserving each group as a rigid body', () => {
+        const nodes = [
+            makeImageNode('a-1', 0, 0),
+            makeImageNode('a-2', 0, 140),
+            makeImageNode('b-1', 40, 40),
+            makeImageNode('b-2', 40, 180),
+        ]
+
+        const result = resolveRigidCanvasNodeGroupCollisions(nodes, [
+            {
+                id: 'group:a',
+                nodeIds: ['a-1', 'a-2'],
+                rect: { x: 0, y: 0, width: 100, height: 240 },
+            },
+            {
+                id: 'group:b',
+                nodeIds: ['b-1', 'b-2'],
+                rect: { x: 40, y: 40, width: 100, height: 240 },
+            },
+        ], {
+            margin: 0,
+            overlapThreshold: 0,
+            iterations: 20,
+        })
+
+        const a1 = result.nodes.find(node => node.nodeId === 'a-1')!
+        const a2 = result.nodes.find(node => node.nodeId === 'a-2')!
+        const b1 = result.nodes.find(node => node.nodeId === 'b-1')!
+        const b2 = result.nodes.find(node => node.nodeId === 'b-2')!
+
+        expect(result.changed).toBe(true)
+        expect(a2.position.x - a1.position.x).toBe(0)
+        expect(a2.position.y - a1.position.y).toBe(140)
+        expect(b2.position.x - b1.position.x).toBe(0)
+        expect(b2.position.y - b1.position.y).toBe(140)
+        expect(rectsOverlap(
+            getGroupRect(result.nodes, ['a-1', 'a-2']),
+            getGroupRect(result.nodes, ['b-1', 'b-2']),
+        )).toBe(false)
     })
 })

--- a/packages/lixpi/canvas-engine/src/shared/collision/resolve-collisions.test.ts
+++ b/packages/lixpi/canvas-engine/src/shared/collision/resolve-collisions.test.ts
@@ -7,6 +7,33 @@ import {
     type CollisionBox,
 } from './resolve-collisions.ts'
 
+function rectsOverlap(
+    a: { x: number; y: number; width: number; height: number },
+    b: { x: number; y: number; width: number; height: number },
+): boolean {
+    return a.x < b.x + b.width
+        && a.x + a.width > b.x
+        && a.y < b.y + b.height
+        && a.y + a.height > b.y
+}
+
+function applyCollisionResult(nodes: CollisionBox[], result: ReturnType<typeof resolveCollisions>): CollisionBox[] {
+    return nodes.map((node) => {
+        const moved = result.nodes.get(node.id)
+        return moved ? { ...node, x: moved.x, y: moved.y } : node
+    })
+}
+
+function expectNoOverlaps(nodes: CollisionBox[]): void {
+    for (let i = 0; i < nodes.length; i++) {
+        for (let j = i + 1; j < nodes.length; j++) {
+            const a = nodes[i]
+            const b = nodes[j]
+            expect(rectsOverlap(a, b), `${a.id} should not overlap ${b.id}`).toBe(false)
+        }
+    }
+}
+
 // =============================================================================
 // BASE COLLISION RESOLUTION
 // =============================================================================
@@ -187,5 +214,36 @@ describe('resolveCollisions', () => {
         expect(result.hasChanges).toBe(false)
         expect(result.numIterations).toBe(1)
         expect(result.nodes.size).toBe(0)
+    })
+
+    it('separates boxes that all start with the exact same center', () => {
+        const nodes: CollisionBox[] = [
+            { id: 'stack-1', x: 0, y: 0, width: 100, height: 100 },
+            { id: 'stack-2', x: 0, y: 0, width: 100, height: 100 },
+            { id: 'stack-3', x: 0, y: 0, width: 100, height: 100 },
+            { id: 'stack-4', x: 0, y: 0, width: 100, height: 100 },
+        ]
+
+        const result = resolveCollisions(nodes, { margin: 0, overlapThreshold: 0, iterations: 100 })
+        const resolved = applyCollisionResult(nodes, result)
+
+        expect(result.hasChanges).toBe(true)
+        expectNoOverlaps(resolved)
+    })
+
+    it('handles non-finite and negative geometry without producing non-finite positions', () => {
+        const result = resolveCollisions([
+            { id: 'bad', x: Number.NaN, y: Number.POSITIVE_INFINITY, width: -100, height: Number.NaN, margin: -20 },
+            { id: 'good', x: 0, y: 0, width: 100, height: 100 },
+        ], {
+            margin: Number.NaN,
+            overlapThreshold: Number.NaN,
+            iterations: Number.POSITIVE_INFINITY,
+        })
+
+        for (const position of result.nodes.values()) {
+            expect(Number.isFinite(position.x)).toBe(true)
+            expect(Number.isFinite(position.y)).toBe(true)
+        }
     })
 })

--- a/packages/lixpi/canvas-engine/src/shared/collision/resolve-collisions.ts
+++ b/packages/lixpi/canvas-engine/src/shared/collision/resolve-collisions.ts
@@ -8,6 +8,14 @@ import type {
     CollisionResult,
 } from './types.ts'
 
+function getFiniteNumber(value: number | undefined, fallback: number): number {
+    return Number.isFinite(value) ? Number(value) : fallback
+}
+
+function getNonNegativeFiniteNumber(value: number | undefined, fallback: number): number {
+    return Math.max(0, getFiniteNumber(value, fallback))
+}
+
 export function resolveCollisions(
     nodes: CollisionBox[],
     options: CollisionOptions = {},
@@ -19,21 +27,27 @@ export function resolveCollisions(
         excludePairs,
         shouldResolvePair,
     } = options
+    const safeIterations = Math.max(0, Math.floor(getFiniteNumber(iterations, 50)))
+    const safeMargin = getNonNegativeFiniteNumber(margin, 20)
+    const safeOverlapThreshold = getNonNegativeFiniteNumber(overlapThreshold, 0.5)
 
-    const boxes = nodes.map(node => ({
-        id: node.id,
-        x: node.x - (node.margin ?? margin),
-        y: node.y - (node.margin ?? margin),
-        width: node.width + (node.margin ?? margin) * 2,
-        height: node.height + (node.margin ?? margin) * 2,
-        margin: node.margin ?? margin,
-        overlapThreshold: node.overlapThreshold ?? overlapThreshold,
-        moved: false,
-    }))
+    const boxes = nodes.map((node) => {
+        const nodeMargin = getNonNegativeFiniteNumber(node.margin, safeMargin)
+        return {
+            id: node.id,
+            x: getFiniteNumber(node.x, 0) - nodeMargin,
+            y: getFiniteNumber(node.y, 0) - nodeMargin,
+            width: getNonNegativeFiniteNumber(node.width, 0) + nodeMargin * 2,
+            height: getNonNegativeFiniteNumber(node.height, 0) + nodeMargin * 2,
+            margin: nodeMargin,
+            overlapThreshold: getNonNegativeFiniteNumber(node.overlapThreshold, safeOverlapThreshold),
+            moved: false,
+        }
+    })
 
     let numIterations = 0
 
-    for (let iter = 0; iter < iterations; iter++) {
+    for (let iter = 0; iter < safeIterations; iter++) {
         let moved = false
 
         for (let i = 0; i < boxes.length; i++) {

--- a/packages/lixpi/constants/ts/types.ts
+++ b/packages/lixpi/constants/ts/types.ts
@@ -528,8 +528,10 @@ export type MediaRunLineageAssignment = {
     reasoningRunId?: string
     mediaRunId?: string
     reasoningModelId?: AiModelId
+    reasoningIndex?: number
     mediaModelId?: AiModelId
     mediaType?: 'image' | 'video'
+    mediaIndex?: number
     branchId: string
     parentMediaNodeId?: string
     // Image-named schema alias. Lineage code uses parentMediaNodeId so
@@ -753,8 +755,10 @@ export type GeneratedMediaVariantMetadata = {
     reasoningRunId?: string
     mediaRunId?: string
     reasoningModelId?: AiModelId
+    reasoningIndex?: number
     mediaModelId?: AiModelId
     mediaType?: 'image' | 'video'
+    mediaIndex?: number
     variantIndex?: number
     // API-assigned lineage marker IDs. The browser applies these to canvas
     // state and may compute layout, but it must not derive branch topology.

--- a/services/api/src/llm/lineage/media-branch-lineage-planner.test.ts
+++ b/services/api/src/llm/lineage/media-branch-lineage-planner.test.ts
@@ -232,6 +232,8 @@ describe('MediaBranchLineagePlanner', () => {
             lineageParentNodeId: 'branch-fork-request-3-reasoning-0',
             reasoningRunId: 'request-3:reasoning:0',
             reasoningModelId: 'Anthropic:claude-sonnet-4-6',
+            reasoningIndex: 0,
+            mediaIndex: 0,
             createdAt: 1700000002000,
             referenceNodeIds: ['portrait-source', 'landscape-source'],
         })
@@ -240,6 +242,8 @@ describe('MediaBranchLineagePlanner', () => {
             lineageParentNodeId: 'branch-fork-request-3-reasoning-1',
             reasoningRunId: 'request-3:reasoning:1',
             reasoningModelId: 'Anthropic:claude-opus-4-1',
+            reasoningIndex: 1,
+            mediaIndex: 0,
             createdAt: 1700000002001,
             referenceNodeIds: ['portrait-source', 'landscape-source'],
         })
@@ -329,6 +333,8 @@ describe('MediaBranchLineagePlanner', () => {
             mediaRunId: 'request-5:reasoning:0:image:0',
             mediaModelId: 'OpenAI:gpt-image-1-mini',
             mediaType: 'image',
+            reasoningIndex: 0,
+            mediaIndex: 0,
             branchForkNodeId: 'branch-fork-request-5-reasoning-0',
             lineageParentNodeId: 'branch-fork-request-5-reasoning-0',
         })
@@ -336,6 +342,8 @@ describe('MediaBranchLineagePlanner', () => {
             mediaRunId: 'request-5:reasoning:0:image:1',
             mediaModelId: 'Google:gemini-2.5-flash-image',
             mediaType: 'image',
+            reasoningIndex: 0,
+            mediaIndex: 1,
             branchForkNodeId: 'branch-fork-request-5-reasoning-0',
         })
     })

--- a/services/api/src/llm/lineage/media-branch-lineage-planner.ts
+++ b/services/api/src/llm/lineage/media-branch-lineage-planner.ts
@@ -400,9 +400,11 @@ export class MediaBranchLineagePlanner {
                 generationRequestId: args.input.generationRequestId,
                 reasoningRunId: run.reasoningRunId,
                 reasoningModelId: run.reasoningModelId,
+                reasoningIndex: run.reasoningIndex,
                 ...(run.mediaRunId ? { mediaRunId: run.mediaRunId } : {}),
                 ...(run.mediaModelId ? { mediaModelId: run.mediaModelId } : {}),
                 ...(run.mediaType ? { mediaType: run.mediaType } : {}),
+                mediaIndex: run.mediaIndex,
                 branchId: args.branchId,
                 ...(args.sourceDecision.parentMediaNodeId
                     ? {

--- a/services/api/src/models/workspace.test.ts
+++ b/services/api/src/models/workspace.test.ts
@@ -11,6 +11,7 @@ const dynamo = {
 }
 
 beforeEach(() => {
+    vi.useRealTimers()
     vi.clearAllMocks()
     ;(globalThis as any).dynamoDBService = dynamo
 })
@@ -372,7 +373,13 @@ describe('Workspace.updateCanvasState', () => {
             name: 'ConditionalCheckFailedException',
         })
         dynamo.updateItem.mockRejectedValueOnce(conditionalFailure)
-        dynamo.getItem.mockResolvedValueOnce({ updatedAt: 22, canvasStateUpdatedAt: 18 })
+        dynamo.getItem
+            .mockResolvedValueOnce({
+                updatedAt: 12,
+                canvasStateUpdatedAt: 12,
+                canvasState: { viewport: { x: 0, y: 0, zoom: 1 }, nodes: [], edges: [] },
+            })
+            .mockResolvedValueOnce({ updatedAt: 22, canvasStateUpdatedAt: 18 })
 
         const result = await Workspace.updateCanvasState({
             userId: 'user-1',
@@ -418,6 +425,236 @@ describe('Workspace.updateCanvasState', () => {
                 ':expectedCanvasStateUpdatedAt': expect.anything(),
             }),
         }))
+    })
+
+    it('keeps canonical API lineage when a browser save contains a stale generated node for the same media run', async () => {
+        vi.useFakeTimers()
+        vi.setSystemTime(1_000_000)
+        dynamo.getItem.mockResolvedValueOnce({
+            updatedAt: 10,
+            canvasStateUpdatedAt: 10,
+            canvasState: {
+                viewport: { x: 0, y: 0, zoom: 1 },
+                nodes: [
+                    {
+                        nodeId: 'fork-1',
+                        type: 'branchFork',
+                        branchId: 'branch-1',
+                        generationRequestId: 'request-1',
+                        reasoningRunId: 'reasoning-1',
+                        reasoningModelId: 'Provider:reasoning',
+                        reasoningIndex: 0,
+                        position: { x: 100, y: 100 },
+                        dimensions: { width: 375, height: 68 },
+                        temporary: true,
+                    },
+                    {
+                        nodeId: 'node-final-file',
+                        type: 'image',
+                        fileId: 'final-file',
+                        workspaceId: 'workspace-1',
+                        src: '/api/images/workspace-1/final-file',
+                        aspectRatio: 1,
+                        position: { x: 500, y: 100 },
+                        dimensions: { width: 800, height: 600 },
+                        generatedBy: {
+                            aiChatThreadId: 'thread-1',
+                            responseId: 'response-1',
+                            aiModel: 'Provider:reasoning',
+                            revisedPrompt: 'prompt',
+                            responseMessageId: '',
+                            generationRequestId: 'request-1',
+                            reasoningRunId: 'reasoning-1',
+                            mediaRunId: 'run-1',
+                            mediaModelId: 'Provider:image',
+                            branchId: 'branch-1',
+                            branchForkNodeId: 'fork-1',
+                            createdAt: 999_000,
+                        },
+                    },
+                ],
+                edges: [{
+                    edgeId: 'edge-fork-1-node-final-file',
+                    sourceNodeId: 'fork-1',
+                    targetNodeId: 'node-final-file',
+                    sourceHandle: 'right',
+                    targetHandle: 'left',
+                }],
+            },
+        })
+        dynamo.updateItem.mockResolvedValue(undefined)
+
+        await Workspace.updateCanvasState({
+            userId: 'user-1',
+            workspaceId: 'workspace-1',
+            expectedCanvasStateUpdatedAt: 10,
+            canvasState: {
+                viewport: { x: 1, y: 2, zoom: 1 },
+                nodes: [
+                    { nodeId: 'user-node', type: 'image', fileId: 'user-file' } as any,
+                    {
+                        nodeId: 'node-partial-file',
+                        type: 'image',
+                        fileId: 'partial-file',
+                        workspaceId: 'workspace-1',
+                        src: '/api/images/workspace-1/partial-file',
+                        aspectRatio: 1,
+                        position: { x: 700, y: 200 },
+                        dimensions: { width: 800, height: 600 },
+                        generatedBy: {
+                            aiChatThreadId: 'thread-1',
+                            responseId: '',
+                            aiModel: 'Provider:reasoning',
+                            revisedPrompt: 'prompt',
+                            responseMessageId: '',
+                            generationRequestId: 'request-1',
+                            reasoningRunId: 'reasoning-1',
+                            mediaRunId: 'run-1',
+                            mediaModelId: 'Provider:image',
+                            branchId: 'branch-1',
+                            branchForkNodeId: 'fork-1',
+                            createdAt: 999_000,
+                        },
+                    },
+                ],
+                edges: [{
+                    edgeId: 'edge-fork-1-node-partial-file',
+                    sourceNodeId: 'fork-1',
+                    targetNodeId: 'node-partial-file',
+                    sourceHandle: 'right',
+                    targetHandle: 'left',
+                }],
+            },
+        })
+
+        const writtenState = dynamo.updateItem.mock.calls[0]?.[0].expressionAttributeValues[':canvasState']
+        expect(writtenState.nodes).toEqual(expect.arrayContaining([
+            expect.objectContaining({ nodeId: 'user-node' }),
+            expect.objectContaining({ nodeId: 'fork-1' }),
+            expect.objectContaining({ nodeId: 'node-final-file', fileId: 'final-file' }),
+        ]))
+        expect(writtenState.nodes).not.toEqual(expect.arrayContaining([
+            expect.objectContaining({ nodeId: 'node-partial-file' }),
+        ]))
+        expect(writtenState.edges).toEqual([
+            expect.objectContaining({ edgeId: 'edge-fork-1-node-final-file' }),
+        ])
+    })
+
+    it('does not resurrect old API generated nodes omitted by a later browser save', async () => {
+        vi.useFakeTimers()
+        vi.setSystemTime(3_600_000)
+        dynamo.getItem.mockResolvedValueOnce({
+            updatedAt: 10,
+            canvasStateUpdatedAt: 10,
+            canvasState: {
+                viewport: { x: 0, y: 0, zoom: 1 },
+                nodes: [
+                    {
+                        nodeId: 'fork-1',
+                        type: 'branchFork',
+                        branchId: 'branch-1',
+                        generationRequestId: 'request-1',
+                        reasoningRunId: 'reasoning-1',
+                        reasoningModelId: 'Provider:reasoning',
+                        reasoningIndex: 0,
+                        position: { x: 100, y: 100 },
+                        dimensions: { width: 375, height: 68 },
+                        temporary: true,
+                    },
+                    {
+                        nodeId: 'node-old-file',
+                        type: 'image',
+                        fileId: 'old-file',
+                        workspaceId: 'workspace-1',
+                        src: '/api/images/workspace-1/old-file',
+                        aspectRatio: 1,
+                        position: { x: 500, y: 100 },
+                        dimensions: { width: 800, height: 600 },
+                        generatedBy: {
+                            aiChatThreadId: 'thread-1',
+                            responseId: 'response-1',
+                            aiModel: 'Provider:reasoning',
+                            revisedPrompt: 'prompt',
+                            responseMessageId: '',
+                            generationRequestId: 'request-1',
+                            reasoningRunId: 'reasoning-1',
+                            mediaRunId: 'run-1',
+                            mediaModelId: 'Provider:image',
+                            branchId: 'branch-1',
+                            branchForkNodeId: 'fork-1',
+                            createdAt: 0,
+                        },
+                    },
+                ],
+                edges: [{
+                    edgeId: 'edge-fork-1-node-old-file',
+                    sourceNodeId: 'fork-1',
+                    targetNodeId: 'node-old-file',
+                    sourceHandle: 'right',
+                    targetHandle: 'left',
+                }],
+            },
+        })
+        dynamo.updateItem.mockResolvedValue(undefined)
+
+        await Workspace.updateCanvasState({
+            userId: 'user-1',
+            workspaceId: 'workspace-1',
+            expectedCanvasStateUpdatedAt: 10,
+            canvasState: {
+                viewport: { x: 0, y: 0, zoom: 1 },
+                nodes: [{ nodeId: 'user-node', type: 'image', fileId: 'user-file' } as any],
+                edges: [],
+            },
+        })
+
+        const writtenState = dynamo.updateItem.mock.calls[0]?.[0].expressionAttributeValues[':canvasState']
+        expect(writtenState.nodes).toEqual([
+            expect.objectContaining({ nodeId: 'user-node' }),
+        ])
+        expect(writtenState.edges).toEqual([])
+    })
+
+    it('does not preserve abandoned marker-only API lineage across full browser saves', async () => {
+        dynamo.getItem.mockResolvedValueOnce({
+            updatedAt: 10,
+            canvasStateUpdatedAt: 10,
+            canvasState: {
+                viewport: { x: 0, y: 0, zoom: 1 },
+                nodes: [{
+                    nodeId: 'fork-unreferenced',
+                    type: 'branchFork',
+                    branchId: 'branch-1',
+                    generationRequestId: 'request-1',
+                    reasoningRunId: 'reasoning-1',
+                    reasoningModelId: 'Provider:reasoning',
+                    reasoningIndex: 0,
+                    position: { x: 100, y: 100 },
+                    dimensions: { width: 375, height: 68 },
+                    temporary: true,
+                }],
+                edges: [],
+            },
+        })
+        dynamo.updateItem.mockResolvedValue(undefined)
+
+        await Workspace.updateCanvasState({
+            userId: 'user-1',
+            workspaceId: 'workspace-1',
+            expectedCanvasStateUpdatedAt: 10,
+            canvasState: {
+                viewport: { x: 0, y: 0, zoom: 1 },
+                nodes: [{ nodeId: 'user-node', type: 'image', fileId: 'user-file' } as any],
+                edges: [],
+            },
+        })
+
+        const writtenState = dynamo.updateItem.mock.calls[0]?.[0].expressionAttributeValues[':canvasState']
+        expect(writtenState.nodes).toEqual([
+            expect.objectContaining({ nodeId: 'user-node' }),
+        ])
+        expect(writtenState.edges).toEqual([])
     })
 
     it('accepts a full canvas save after file upload changes only workspace updatedAt', async () => {
@@ -486,7 +723,10 @@ describe('Workspace.updateCanvasState', () => {
             updatedAt: expect.any(Number),
             canvasStateUpdatedAt: expect.any(Number),
         })
-        expect(dynamo.getItem).not.toHaveBeenCalled()
+        expect(dynamo.getItem).toHaveBeenCalledWith(expect.objectContaining({
+            key: { workspaceId: 'workspace-1' },
+            origin: 'updateWorkspaceCanvasState:get',
+        }))
         expect(workspaceItem.canvasState).toEqual(expect.objectContaining({
             nodes: [expect.objectContaining({ fileId: 'uploaded-file' })],
         }))

--- a/services/api/src/models/workspace.ts
+++ b/services/api/src/models/workspace.ts
@@ -43,6 +43,32 @@ type WorkspaceWithCanvasToken = Partial<Workspace> & {
     canvasStateUpdatedAt?: number
 }
 
+type CanvasEdge = CanvasState['edges'][number]
+
+type ApiLineageGeneratedBy = {
+    generationRequestId?: string
+    reasoningRunId?: string
+    mediaRunId?: string
+    reasoningModelId?: string
+    mediaModelId?: string
+    mediaType?: 'image' | 'video'
+    branchId?: string
+    parentMediaNodeId?: string
+    parentImageNodeId?: string
+    branchOriginNodeId?: string
+    branchForkNodeId?: string
+    branchLineNodeId?: string
+    createdAt?: number
+}
+
+type ApiLineageCanvasNode = CanvasNode & {
+    generatedBy?: ApiLineageGeneratedBy
+    generationRequestId?: string
+    branchId?: string
+}
+
+const API_GENERATED_MEDIA_FULL_SAVE_PROTECTION_MS = 30 * 60 * 1000
+
 const addFileId = (fileIds: Set<string>, fileId: unknown): void => {
     if (typeof fileId === 'string' && fileId.length > 0) {
         fileIds.add(fileId)
@@ -64,6 +90,157 @@ const getCanvasStateWriteCondition = (hasExpectedCanvasStateUpdatedAt: boolean):
     }
 
     return '(#canvasStateUpdatedAt = :expectedCanvasStateUpdatedAt OR (attribute_not_exists(#canvasStateUpdatedAt) AND #updatedAt = :expectedCanvasStateUpdatedAt))'
+}
+
+const normalizeCanvasState = (canvasState: CanvasState | undefined): CanvasState => ({
+    viewport: canvasState?.viewport ?? { x: 0, y: 0, zoom: 1 },
+    nodes: canvasState?.nodes ?? [],
+    edges: canvasState?.edges ?? []
+})
+
+const isBranchMarkerNode = (node: CanvasNode): boolean =>
+    node.type === 'branchOrigin' || node.type === 'branchFork' || node.type === 'branchLine'
+
+const isApiGeneratedMediaNode = (node: CanvasNode): node is ApiLineageCanvasNode =>
+    (node.type === 'image' || node.type === 'video')
+    && Boolean(
+        (node as ApiLineageCanvasNode).generatedBy?.generationRequestId
+        || (node as ApiLineageCanvasNode).generatedBy?.mediaRunId
+        || (node as ApiLineageCanvasNode).generatedBy?.branchId
+    )
+
+const isApiLineageNode = (node: CanvasNode): node is ApiLineageCanvasNode =>
+    isBranchMarkerNode(node) || isApiGeneratedMediaNode(node)
+
+const getApiLineageNodeStableKey = (node: ApiLineageCanvasNode): string => {
+    if (isBranchMarkerNode(node)) return `marker:${node.nodeId}`
+
+    const generatedBy = node.generatedBy
+    if (generatedBy?.mediaRunId) return `generated-media-run:${generatedBy.mediaRunId}`
+    if (generatedBy?.generationRequestId && generatedBy.reasoningRunId && generatedBy.mediaModelId) {
+        return `generated-media:${generatedBy.generationRequestId}:${generatedBy.reasoningRunId}:${generatedBy.mediaModelId}`
+    }
+
+    return `generated-media-node:${node.nodeId}`
+}
+
+const isFreshApiGeneratedMediaNode = (node: ApiLineageCanvasNode, currentDate: number): boolean => {
+    if (!isApiGeneratedMediaNode(node)) return false
+
+    const createdAt = node.generatedBy?.createdAt
+    if (typeof createdAt !== 'number') return false
+
+    return currentDate - createdAt <= API_GENERATED_MEDIA_FULL_SAVE_PROTECTION_MS
+}
+
+const addGeneratedLineageMarkerRefs = (node: ApiLineageCanvasNode, refs: Set<string>): void => {
+    const generatedBy = node.generatedBy
+    addFileId(refs, generatedBy?.branchOriginNodeId)
+    addFileId(refs, generatedBy?.branchForkNodeId)
+    addFileId(refs, generatedBy?.branchLineNodeId)
+}
+
+const applyIncomingLayoutFields = (currentNode: ApiLineageCanvasNode, incomingNode: ApiLineageCanvasNode): CanvasNode => {
+    const merged = { ...incomingNode, ...currentNode } as Record<string, unknown>
+
+    if ('position' in incomingNode) merged.position = incomingNode.position
+    if ('dimensions' in incomingNode) merged.dimensions = incomingNode.dimensions
+    if ('parentId' in incomingNode) merged.parentId = incomingNode.parentId
+    if ('extent' in incomingNode) merged.extent = incomingNode.extent
+    if ('expandParent' in incomingNode) merged.expandParent = incomingNode.expandParent
+
+    return merged as CanvasNode
+}
+
+function mergeApiLineageForFullCanvasSave(
+    currentCanvasState: CanvasState,
+    incomingCanvasState: CanvasState,
+    currentDate: number
+): CanvasState {
+    const currentApiNodes = currentCanvasState.nodes.filter(isApiLineageNode)
+    if (currentApiNodes.length === 0) return incomingCanvasState
+
+    const currentApiNodesById = new Map(currentApiNodes.map(node => [node.nodeId, node]))
+    const currentApiNodesByStableKey = new Map(currentApiNodes.map(node => [getApiLineageNodeStableKey(node), node]))
+    const incomingApiNodeIds = new Set<string>()
+    const protectedMarkerNodeIds = new Set<string>()
+    const nextNodes: CanvasNode[] = []
+    const includedNodeIds = new Set<string>()
+
+    const includeNode = (node: CanvasNode): void => {
+        if (includedNodeIds.has(node.nodeId)) {
+            const index = nextNodes.findIndex(candidate => candidate.nodeId === node.nodeId)
+            if (index >= 0) nextNodes[index] = node
+            return
+        }
+
+        nextNodes.push(node)
+        includedNodeIds.add(node.nodeId)
+    }
+
+    for (const incomingNode of incomingCanvasState.nodes) {
+        if (!isApiLineageNode(incomingNode)) {
+            includeNode(incomingNode)
+            continue
+        }
+
+        incomingApiNodeIds.add(incomingNode.nodeId)
+        const stableKey = getApiLineageNodeStableKey(incomingNode)
+        const currentNode = currentApiNodesByStableKey.get(stableKey)
+
+        if (!currentNode) continue
+
+        if (isApiGeneratedMediaNode(currentNode)) addGeneratedLineageMarkerRefs(currentNode, protectedMarkerNodeIds)
+
+        const nodeToInclude = currentNode.nodeId === incomingNode.nodeId
+            ? applyIncomingLayoutFields(currentNode, incomingNode)
+            : currentNode
+        includeNode(nodeToInclude)
+    }
+
+    for (const currentNode of currentApiNodes) {
+        if (includedNodeIds.has(currentNode.nodeId)) continue
+
+        if (isBranchMarkerNode(currentNode)) continue
+        if (!isFreshApiGeneratedMediaNode(currentNode, currentDate)) continue
+
+        addGeneratedLineageMarkerRefs(currentNode, protectedMarkerNodeIds)
+        includeNode(currentNode)
+    }
+
+    for (const currentNode of currentApiNodes) {
+        if (includedNodeIds.has(currentNode.nodeId)) continue
+        if (!isBranchMarkerNode(currentNode)) continue
+
+        if (protectedMarkerNodeIds.has(currentNode.nodeId)) {
+            includeNode(currentNode)
+        }
+    }
+
+    const apiNodeIds = new Set([
+        ...currentApiNodes.map(node => node.nodeId),
+        ...incomingApiNodeIds,
+    ])
+    const nextNodeIds = new Set(nextNodes.map(node => node.nodeId))
+    const nextEdgesById = new Map<string, CanvasEdge>()
+
+    for (const edge of incomingCanvasState.edges ?? []) {
+        if (apiNodeIds.has(edge.sourceNodeId) || apiNodeIds.has(edge.targetNodeId)) continue
+        if (!nextNodeIds.has(edge.sourceNodeId) || !nextNodeIds.has(edge.targetNodeId)) continue
+        nextEdgesById.set(edge.edgeId, edge)
+    }
+
+    for (const edge of currentCanvasState.edges ?? []) {
+        if (!currentApiNodesById.has(edge.sourceNodeId) && !currentApiNodesById.has(edge.targetNodeId)) continue
+        if (!nextNodeIds.has(edge.sourceNodeId) || !nextNodeIds.has(edge.targetNodeId)) continue
+        nextEdgesById.set(edge.edgeId, edge)
+    }
+
+    return {
+        ...incomingCanvasState,
+        nodes: nextNodes,
+        edges: [...nextEdgesById.values()],
+    }
 }
 
 const getCanvasStateReferencedFileIds = (canvasState: CanvasState | null | undefined): Set<string> => {
@@ -300,6 +477,17 @@ export default {
         const hasExpectedCanvasStateUpdatedAt = canvasStateSaveToken !== undefined
 
         try {
+            const currentWorkspace = await dynamoDBService.getItem({
+                tableName: getDynamoDbTableStageName('WORKSPACES', ORG_NAME, STAGE),
+                key: { workspaceId },
+                origin: 'updateWorkspaceCanvasState:get'
+            })
+            const nextCanvasState = mergeApiLineageForFullCanvasSave(
+                normalizeCanvasState(currentWorkspace?.canvasState),
+                normalizeCanvasState(canvasState),
+                currentDate
+            )
+
             await dynamoDBService.updateItem({
                 tableName: getDynamoDbTableStageName('WORKSPACES', ORG_NAME, STAGE),
                 key: { workspaceId },
@@ -311,7 +499,7 @@ export default {
                     '#canvasStateUpdatedAt': 'canvasStateUpdatedAt'
                 },
                 expressionAttributeValues: {
-                    ':canvasState': canvasState,
+                    ':canvasState': nextCanvasState,
                     ':updatedAt': currentDate,
                     ':canvasStateUpdatedAt': currentDate,
                     ...(hasExpectedCanvasStateUpdatedAt ? { ':expectedCanvasStateUpdatedAt': canvasStateSaveToken } : {})
@@ -370,11 +558,7 @@ export default {
                 return false
             }
 
-            const currentCanvasState: CanvasState = {
-                viewport: workspace.canvasState?.viewport ?? { x: 0, y: 0, zoom: 1 },
-                nodes: workspace.canvasState?.nodes ?? [],
-                edges: workspace.canvasState?.edges ?? []
-            }
+            const currentCanvasState = normalizeCanvasState(workspace.canvasState)
             const result = mutate(currentCanvasState)
             if (!result.changed) return false
 

--- a/services/api/src/services/media-generation-canvas-projection.test.ts
+++ b/services/api/src/services/media-generation-canvas-projection.test.ts
@@ -1,6 +1,6 @@
 'use strict'
 
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { CanvasState, MediaBranchLineagePlan, MediaGenerationRunMeta } from '@lixpi/constants'
 
 const workspaceMutateCanvasState = vi.hoisted(() => vi.fn())
@@ -27,6 +27,48 @@ const latestMutator = (): ((canvasState: CanvasState) => { canvasState: CanvasSt
     const call = workspaceMutateCanvasState.mock.calls.at(-1)
     expect(call).toBeDefined()
     return call![0].mutate
+}
+
+const nodeRect = (node: CanvasState['nodes'][number]): { x: number; y: number; width: number; height: number } => ({
+    x: node.position.x,
+    y: node.position.y,
+    width: node.dimensions.width,
+    height: node.dimensions.height,
+})
+
+const groupRect = (nodes: CanvasState['nodes']): { x: number; y: number; width: number; height: number } => {
+    const minX = Math.min(...nodes.map(node => node.position.x))
+    const minY = Math.min(...nodes.map(node => node.position.y))
+    const maxX = Math.max(...nodes.map(node => node.position.x + node.dimensions.width))
+    const maxY = Math.max(...nodes.map(node => node.position.y + node.dimensions.height))
+    return {
+        x: minX,
+        y: minY,
+        width: maxX - minX,
+        height: maxY - minY,
+    }
+}
+
+const rectsOverlap = (
+    a: { x: number; y: number; width: number; height: number },
+    b: { x: number; y: number; width: number; height: number },
+): boolean =>
+    a.x < b.x + b.width
+    && a.x + a.width > b.x
+    && a.y < b.y + b.height
+    && a.y + a.height > b.y
+
+const expectNoOverlappingRects = (rects: Array<{ id: string; rect: { x: number; y: number; width: number; height: number } }>): void => {
+    for (let i = 0; i < rects.length; i++) {
+        for (let j = i + 1; j < rects.length; j++) {
+            const a = rects[i]
+            const b = rects[j]
+            expect(
+                rectsOverlap(a.rect, b.rect),
+                `${a.id} should not overlap ${b.id}`
+            ).toBe(false)
+        }
+    }
 }
 
 const lineagePlan = (): MediaBranchLineagePlan => ({
@@ -110,8 +152,10 @@ const generationRun = (): MediaGenerationRunMeta => ({
         reasoningRunId: 'reasoning-1',
         mediaRunId: 'media-1',
         reasoningModelId: 'Anthropic:claude-sonnet-4-6',
+        reasoningIndex: 0,
         mediaModelId: 'Google:gemini-2.5-flash-image',
         mediaType: 'image',
+        mediaIndex: 0,
         branchId: 'branch-1',
         branchOriginNodeId: 'origin-1',
         branchForkNodeId: 'fork-1',
@@ -125,9 +169,105 @@ const generationRun = (): MediaGenerationRunMeta => ({
     },
 })
 
+const matrixLineagePlan = (): MediaBranchLineagePlan => {
+    const generationRequestId = 'matrix-request-1'
+    const branchId = 'branch-matrix-1'
+    const reasoningModelIds = [
+        'Anthropic:claude-sonnet-4-6',
+        'OpenAI:gpt-5.5',
+        'Google:gemini-3-pro',
+    ] as const
+    const imageModelIds = [
+        'Google:gemini-3-pro-image',
+        'Google:nano-banana-pro',
+        'OpenAI:gpt-image-2',
+        'OpenAI:gpt-image-1.5',
+    ] as const
+    const branchForks = reasoningModelIds.map((reasoningModelId, reasoningIndex) => {
+        const reasoningRunId = `${generationRequestId}:reasoning:${reasoningIndex}`
+        return {
+            nodeId: `branch-fork-${generationRequestId}-reasoning-${reasoningIndex}`,
+            generationRequestId,
+            branchId,
+            reasoningRunId,
+            reasoningModelId,
+            reasoningIndex,
+            provenance: {
+                kind: 'reasoning-run',
+                promptText: 'matrix prompt',
+                referenceNodeIds: ['ref-1'],
+                sourceContextNodeIds: ['ctx-1'],
+                reasoningRunId,
+                reasoningModelId,
+                reasoningIndex,
+            },
+        } satisfies MediaBranchLineagePlan['branchForks'][number]
+    })
+    const runAssignments = branchForks.flatMap((fork, reasoningIndex) =>
+        imageModelIds.map((mediaModelId, mediaIndex) => ({
+            generationRequestId,
+            reasoningRunId: fork.reasoningRunId,
+            mediaRunId: `${fork.reasoningRunId}:image:${mediaIndex}`,
+            reasoningModelId: fork.reasoningModelId,
+            reasoningIndex,
+            mediaModelId,
+            mediaType: 'image' as const,
+            mediaIndex,
+            branchId,
+            branchForkNodeId: fork.nodeId,
+            lineageParentNodeId: fork.nodeId,
+            referenceNodeIds: ['ref-1'],
+            sourceContextNodeIds: ['ctx-1'],
+            operationKind: 'new_image' as const,
+            promptText: 'matrix prompt',
+            promptFingerprint: 'matrix-prompt',
+            createdAt: 10_000 + reasoningIndex * imageModelIds.length + mediaIndex,
+        }))
+    )
+
+    return {
+        planVersion: 'media-branch-lineage-v1',
+        generationRequestId,
+        branchId,
+        promptText: 'matrix prompt',
+        promptFingerprint: 'matrix-prompt',
+        referenceNodeIds: ['ref-1'],
+        sourceContextNodeIds: ['ctx-1'],
+        branchForks,
+        branchLines: [],
+        runAssignments,
+        createdAt: 10_000,
+    }
+}
+
+const generationRunFromAssignment = (
+    assignment: MediaBranchLineagePlan['runAssignments'][number],
+    variantIndex: number,
+): MediaGenerationRunMeta => ({
+    requestKind: 'media-generation-matrix',
+    generationRequestId: assignment.generationRequestId,
+    reasoningRunId: assignment.reasoningRunId!,
+    mediaRunId: assignment.mediaRunId,
+    reasoningModelId: assignment.reasoningModelId!,
+    mediaModelId: assignment.mediaModelId,
+    mediaType: assignment.mediaType,
+    reasoningIndex: assignment.reasoningIndex ?? 0,
+    mediaIndex: assignment.mediaIndex,
+    variantIndex,
+    lineageAssignment: assignment,
+})
+
+let consoleInfoSpy: ReturnType<typeof vi.spyOn> | null = null
+
 describe('media-generation-canvas-projection', () => {
     beforeEach(() => {
         vi.clearAllMocks()
+        consoleInfoSpy = vi.spyOn(console, 'info').mockImplementation(() => undefined)
+    })
+
+    afterEach(() => {
+        consoleInfoSpy?.mockRestore()
+        consoleInfoSpy = null
     })
 
     it('projects API media lineage plans into durable branch marker nodes and edges idempotently', async () => {
@@ -209,6 +349,78 @@ describe('media-generation-canvas-projection', () => {
         expect(second.changed).toBe(false)
     })
 
+    it('removes stale marker edges targeting a generated image before adding the assignment edge', async () => {
+        const run = generationRun()
+
+        await upsertGeneratedImageToCanvas({
+            workspaceId: 'workspace-1',
+            aiChatThreadId: 'thread-1',
+            imageUrl: '/api/images/workspace-1/file-1',
+            fileId: 'file-1',
+            responseId: 'response-1',
+            revisedPrompt: 'a brighter image',
+            aiProvider: 'Google',
+            imageModelProvider: 'Google',
+            imageModelId: 'gemini-2.5-flash-image',
+            generationRun: run,
+        })
+
+        const canvasWithStaleMarkerEdge: CanvasState = {
+            ...emptyCanvasState(),
+            nodes: [
+                {
+                    nodeId: 'fork-other',
+                    type: 'branchFork',
+                    branchId: 'branch-other',
+                    generationRequestId: 'request-other',
+                    reasoningRunId: 'reasoning-other',
+                    reasoningModelId: 'OpenAI:gpt-5.5',
+                    reasoningIndex: 1,
+                    position: { x: 0, y: 0 },
+                    dimensions: { width: 375, height: 68 },
+                    temporary: true,
+                } as any,
+                {
+                    nodeId: 'user-node',
+                    type: 'image',
+                    fileId: 'user-file',
+                    workspaceId: 'workspace-1',
+                    src: '/api/images/workspace-1/user-file',
+                    aspectRatio: 1,
+                    position: { x: 0, y: 100 },
+                    dimensions: { width: 100, height: 100 },
+                } as any,
+            ],
+            edges: [
+                {
+                    edgeId: 'edge-fork-other-node-file-1',
+                    sourceNodeId: 'fork-other',
+                    targetNodeId: 'node-file-1',
+                    sourceHandle: 'right',
+                    targetHandle: 'left',
+                },
+                {
+                    edgeId: 'edge-user-node-node-file-1',
+                    sourceNodeId: 'user-node',
+                    targetNodeId: 'node-file-1',
+                    sourceHandle: 'right',
+                    targetHandle: 'left',
+                },
+            ],
+        }
+
+        const result = latestMutator()(canvasWithStaleMarkerEdge)
+
+        expect(result.changed).toBe(true)
+        expect(result.canvasState.edges).toEqual(expect.arrayContaining([
+            expect.objectContaining({ edgeId: 'edge-user-node-node-file-1', sourceNodeId: 'user-node', targetNodeId: 'node-file-1' }),
+            expect.objectContaining({ edgeId: 'edge-fork-1-node-file-1', sourceNodeId: 'fork-1', targetNodeId: 'node-file-1' }),
+        ]))
+        expect(result.canvasState.edges).not.toEqual(expect.arrayContaining([
+            expect.objectContaining({ edgeId: 'edge-fork-other-node-file-1' }),
+        ]))
+    })
+
     it('still reports a changed canvas when an existing media node only needs missing lineage markers', async () => {
         const run = generationRun()
         await upsertGeneratedImageToCanvas({
@@ -256,6 +468,134 @@ describe('media-generation-canvas-projection', () => {
         expect(result.canvasState.edges).toEqual(expect.arrayContaining([
             expect.objectContaining({ sourceNodeId: 'fork-1', targetNodeId: 'node-file-1' }),
         ]))
+    })
+
+    it('recreates missing assignment markers with the planned reasoning index instead of collapsing them to zero', async () => {
+        const run: MediaGenerationRunMeta = {
+            ...generationRun(),
+            reasoningRunId: 'reasoning-3',
+            mediaRunId: 'media-3',
+            reasoningModelId: 'Google:gemini-3-pro',
+            reasoningIndex: 2,
+            mediaIndex: 1,
+            variantIndex: 9,
+            lineageAssignment: {
+                ...generationRun().lineageAssignment!,
+                reasoningRunId: 'reasoning-3',
+                mediaRunId: 'media-3',
+                reasoningModelId: 'Google:gemini-3-pro',
+                reasoningIndex: 2,
+                mediaIndex: 1,
+                branchForkNodeId: 'fork-3',
+                lineageParentNodeId: 'fork-3',
+            },
+        }
+
+        await upsertGeneratedImageToCanvas({
+            workspaceId: 'workspace-1',
+            aiChatThreadId: 'thread-1',
+            imageUrl: '/api/images/workspace-1/file-3',
+            fileId: 'file-3',
+            responseId: 'response-3',
+            revisedPrompt: 'a brighter image',
+            aiProvider: 'Google',
+            imageModelProvider: 'Google',
+            imageModelId: 'gemini-3-pro-image',
+            generationRun: run,
+        })
+
+        const result = latestMutator()(emptyCanvasState())
+
+        expect(result.canvasState.nodes).toEqual(expect.arrayContaining([
+            expect.objectContaining({
+                nodeId: 'fork-3',
+                type: 'branchFork',
+                reasoningRunId: 'reasoning-3',
+                reasoningIndex: 2,
+            }),
+            expect.objectContaining({
+                nodeId: 'node-file-3',
+                generatedBy: expect.objectContaining({
+                    reasoningRunId: 'reasoning-3',
+                    mediaRunId: 'media-3',
+                    reasoningIndex: 2,
+                    mediaIndex: 1,
+                    variantIndex: 9,
+                    branchForkNodeId: 'fork-3',
+                }),
+            }),
+        ]))
+    })
+
+    it('keeps a 3x4 reasoning/media matrix as three balanced branch trees with one correct fork edge per output', async () => {
+        const plan = matrixLineagePlan()
+        let state = emptyCanvasState()
+
+        await upsertMediaLineagePlanToCanvas({
+            workspaceId: 'workspace-1',
+            aiChatThreadId: 'thread-1',
+            lineagePlan: plan,
+        })
+        state = latestMutator()(state).canvasState
+
+        for (const assignmentIndex of [7, 0, 11, 3, 5, 1, 10, 2, 8, 4, 6, 9]) {
+            const assignment = plan.runAssignments[assignmentIndex]
+            const safeFileId = `file-${assignment.mediaRunId!.replace(/[^a-zA-Z0-9-]/g, '-')}`
+            await upsertGeneratedImageToCanvas({
+                workspaceId: 'workspace-1',
+                aiChatThreadId: 'thread-1',
+                imageUrl: `/api/images/workspace-1/${safeFileId}`,
+                fileId: safeFileId,
+                responseId: `response-${assignmentIndex}`,
+                revisedPrompt: 'matrix result',
+                aiProvider: 'Anthropic',
+                imageModelProvider: assignment.mediaModelId!.split(':')[0],
+                imageModelId: assignment.mediaModelId!.split(':').slice(1).join(':'),
+                generationRun: generationRunFromAssignment(assignment, assignmentIndex),
+            })
+            state = latestMutator()(state).canvasState
+        }
+
+        const forkNodes = state.nodes.filter(node => node.type === 'branchFork')
+        const generatedNodes = state.nodes.filter(node => node.type === 'image' && Boolean(node.generatedBy?.mediaRunId))
+        const nodeIds = new Set(state.nodes.map(node => node.nodeId))
+
+        expect(forkNodes).toHaveLength(3)
+        expect(generatedNodes).toHaveLength(12)
+        expect(state.edges.every(edge => nodeIds.has(edge.sourceNodeId) && nodeIds.has(edge.targetNodeId))).toBe(true)
+        expect(new Set(generatedNodes.map(node => node.generatedBy?.mediaRunId)).size).toBe(12)
+
+        const branchGroupRects = forkNodes.map((fork) => {
+            const branchChildren = generatedNodes
+                .filter(node => node.generatedBy?.branchForkNodeId === fork.nodeId)
+                .sort((a, b) => a.position.y - b.position.y)
+            expect(branchChildren).toHaveLength(4)
+            expect(branchChildren.map(node => node.generatedBy?.reasoningIndex)).toEqual([
+                fork.reasoningIndex,
+                fork.reasoningIndex,
+                fork.reasoningIndex,
+                fork.reasoningIndex,
+            ])
+            expect(branchChildren.map(node => node.generatedBy?.mediaIndex)).toEqual([0, 1, 2, 3])
+            expectNoOverlappingRects(branchChildren.map(node => ({ id: node.nodeId, rect: nodeRect(node) })))
+
+            for (const child of branchChildren) {
+                const inboundEdges = state.edges.filter(edge => edge.targetNodeId === child.nodeId)
+                expect(inboundEdges).toEqual([
+                    expect.objectContaining({
+                        sourceNodeId: fork.nodeId,
+                        targetNodeId: child.nodeId,
+                    }),
+                ])
+            }
+
+            return {
+                id: fork.nodeId,
+                rect: groupRect([fork, ...branchChildren]),
+            }
+        })
+
+        expectNoOverlappingRects(branchGroupRects)
     })
 
     it('persists final generated videos with poster metadata and parsed dimensions', async () => {

--- a/services/api/src/services/media-generation-canvas-projection.ts
+++ b/services/api/src/services/media-generation-canvas-projection.ts
@@ -243,6 +243,14 @@ function isGeneratedMediaLineageNode(node: CanvasNode): node is GeneratedMediaNo
     return (node.type === 'image' || node.type === 'video') && Boolean(node.generatedBy?.branchId)
 }
 
+function getGeneratedMediaLineageParentNodeId(node: GeneratedMediaNode): string | undefined {
+    return node.generatedBy?.branchLineNodeId
+        ?? node.generatedBy?.branchForkNodeId
+        ?? node.generatedBy?.branchOriginNodeId
+        ?? node.generatedBy?.parentMediaNodeId
+        ?? node.generatedBy?.parentImageNodeId
+}
+
 function isLineageCollisionNode(node: CanvasNode): node is LineageCollisionNode {
     return isTopLevelNode(node) && (isMarkerNode(node) || isGeneratedMediaLineageNode(node))
 }
@@ -414,6 +422,72 @@ function resolveCanvasProjectionCollisions(
     }
 }
 
+function compareOptionalNumber(a: number | undefined, b: number | undefined): number {
+    const normalizedA = Number.isFinite(a) ? Number(a) : Number.MAX_SAFE_INTEGER
+    const normalizedB = Number.isFinite(b) ? Number(b) : Number.MAX_SAFE_INTEGER
+    return normalizedA - normalizedB
+}
+
+function compareOptionalString(a: string | undefined, b: string | undefined): number {
+    return (a ?? '').localeCompare(b ?? '')
+}
+
+function compareGeneratedMediaSiblingOrder(a: GeneratedMediaNode, b: GeneratedMediaNode): number {
+    return compareOptionalNumber(a.generatedBy?.reasoningIndex, b.generatedBy?.reasoningIndex)
+        || compareOptionalNumber(a.generatedBy?.createdAt, b.generatedBy?.createdAt)
+        || compareOptionalNumber(a.generatedBy?.variantIndex, b.generatedBy?.variantIndex)
+        || compareOptionalNumber(a.generatedBy?.mediaIndex, b.generatedBy?.mediaIndex)
+        || compareOptionalString(a.generatedBy?.mediaType, b.generatedBy?.mediaType)
+        || compareOptionalString(a.generatedBy?.mediaModelId, b.generatedBy?.mediaModelId)
+        || compareOptionalString(a.generatedBy?.mediaRunId, b.generatedBy?.mediaRunId)
+        || a.nodeId.localeCompare(b.nodeId)
+}
+
+function rebalanceGeneratedMediaChildren(
+    state: CanvasState,
+    lineageParentNodeId: string | undefined,
+): { state: CanvasState; changed: boolean } {
+    if (!lineageParentNodeId) return { state, changed: false }
+
+    const parentNode = findNode(state.nodes, lineageParentNodeId)
+    if (!parentNode) return { state, changed: false }
+
+    const siblings = state.nodes
+        .filter((node): node is GeneratedMediaNode => isGeneratedMediaLineageNode(node))
+        .filter(node => getGeneratedMediaLineageParentNodeId(node) === lineageParentNodeId)
+        .sort(compareGeneratedMediaSiblingOrder)
+
+    if (siblings.length <= 1) return { state, changed: false }
+
+    const totalHeight = siblings.reduce((height, node) => height + node.dimensions.height, 0)
+        + canvasProjectionSettings.branchRowGap * Math.max(0, siblings.length - 1)
+    const parentCenterY = parentNode.position.y + parentNode.dimensions.height / 2
+    const childX = parentNode.position.x + parentNode.dimensions.width + getGapToGeneratedMedia(parentNode)
+    let childY = parentCenterY - totalHeight / 2
+    let changed = false
+    const nextPositionsByNodeId = new Map<string, { x: number; y: number }>()
+
+    for (const sibling of siblings) {
+        const position = { x: childX, y: childY }
+        nextPositionsByNodeId.set(sibling.nodeId, position)
+        changed = changed || sibling.position.x !== position.x || sibling.position.y !== position.y
+        childY += sibling.dimensions.height + canvasProjectionSettings.branchRowGap
+    }
+
+    if (!changed) return { state, changed: false }
+
+    return {
+        state: {
+            ...state,
+            nodes: state.nodes.map((node) => {
+                const position = nextPositionsByNodeId.get(node.nodeId)
+                return position ? { ...node, position } as CanvasNode : node
+            }),
+        },
+        changed: true,
+    }
+}
+
 function getGeneratedMediaPosition(
     sourceNode: CanvasNode | undefined,
     nodes: CanvasNode[],
@@ -457,10 +531,14 @@ function findGeneratedMediaNodeForRun(
         if (fileId && node.fileId === fileId) return true
         const generatedBy = node.generatedBy
         if (!generatedBy || !generationRun) return false
-        if (generationRun.mediaRunId && generatedBy.mediaRunId === generationRun.mediaRunId) return true
+        if (generationRun.mediaRunId && generatedBy.mediaRunId) {
+            return generatedBy.mediaRunId === generationRun.mediaRunId
+        }
         return Boolean(
             generationRun.generationRequestId
             && generatedBy.generationRequestId === generationRun.generationRequestId
+            && generationRun.reasoningRunId
+            && generatedBy.reasoningRunId === generationRun.reasoningRunId
             && generationRun.mediaModelId
             && generatedBy.mediaModelId === generationRun.mediaModelId
         )
@@ -654,7 +732,7 @@ function markerNodesFromAssignment(
             aiChatThreadId,
             ...(assignment.reasoningRunId ? { reasoningRunId: assignment.reasoningRunId } : {}),
             ...(assignment.reasoningModelId ? { reasoningModelId: assignment.reasoningModelId } : {}),
-            reasoningIndex: 0,
+            reasoningIndex: assignment.reasoningIndex ?? 0,
             ...(parentBranchNodeId ? { parentBranchNodeId } : {}),
             position: parentBranchNodeId
                 ? positionBranchMarkerBeforeGeneratedMedia(parentNode, markerDimensions(), markers.length, state, canvasVisibleArea)
@@ -674,7 +752,7 @@ function markerNodesFromAssignment(
             aiChatThreadId,
             ...(assignment.reasoningRunId ? { reasoningRunId: assignment.reasoningRunId } : {}),
             ...(assignment.reasoningModelId ? { reasoningModelId: assignment.reasoningModelId } : {}),
-            reasoningIndex: 0,
+            reasoningIndex: assignment.reasoningIndex ?? 0,
             ...(assignment.mediaRunId ? { mediaRunId: assignment.mediaRunId } : {}),
             ...(assignment.mediaModelId ? { mediaModelId: assignment.mediaModelId } : {}),
             ...(assignment.mediaType ? { mediaType: assignment.mediaType } : {}),
@@ -720,8 +798,10 @@ function generatedByLineage(assignment: MediaRunLineageAssignment | undefined): 
         ...(assignment.reasoningRunId ? { reasoningRunId: assignment.reasoningRunId } : {}),
         ...(assignment.mediaRunId ? { mediaRunId: assignment.mediaRunId } : {}),
         ...(assignment.reasoningModelId ? { reasoningModelId: assignment.reasoningModelId } : {}),
+        ...(assignment.reasoningIndex !== undefined ? { reasoningIndex: assignment.reasoningIndex } : {}),
         ...(assignment.mediaModelId ? { mediaModelId: assignment.mediaModelId } : {}),
         ...(assignment.mediaType ? { mediaType: assignment.mediaType } : {}),
+        ...(assignment.mediaIndex !== undefined ? { mediaIndex: assignment.mediaIndex } : {}),
         branchId: assignment.branchId,
         ...(assignment.parentMediaNodeId ? { parentMediaNodeId: assignment.parentMediaNodeId } : {}),
         ...(assignment.parentImageNodeId ? { parentImageNodeId: assignment.parentImageNodeId } : {}),
@@ -743,14 +823,21 @@ function addGeneratedMediaEdge(
     targetNodeId: string,
 ): { state: CanvasState; changed: boolean } {
     if (!sourceNodeId) return { state, changed: false }
-    const edgeResult = addEdgeIfMissing(state.edges ?? [], {
+    const markerNodeIds = new Set(state.nodes.filter(isMarkerNode).map(node => node.nodeId))
+    const edges = state.edges ?? []
+    const prunedEdges = edges.filter(edge => {
+        if (edge.targetNodeId !== targetNodeId) return true
+        if (edge.sourceNodeId === sourceNodeId) return true
+        return !markerNodeIds.has(edge.sourceNodeId) && !edge.edgeId.startsWith('edge-branch-')
+    })
+    const edgeResult = addEdgeIfMissing(prunedEdges, {
         edgeId: `edge-${sourceNodeId}-${targetNodeId}`,
         sourceNodeId,
         targetNodeId,
         sourceHandle: 'right',
         targetHandle: 'left',
     })
-    return { state: { ...state, edges: edgeResult.edges }, changed: edgeResult.changed }
+    return { state: { ...state, edges: edgeResult.edges }, changed: prunedEdges.length !== edges.length || edgeResult.changed }
 }
 
 function isImageNode(node: CanvasNode | undefined): node is ImageCanvasNode {
@@ -815,6 +902,7 @@ export async function upsertGeneratedImageToCanvas(params: UpsertImageInput): Pr
                     revisedPrompt: params.revisedPrompt || assignment.promptText,
                     responseMessageId: '',
                     ...generatedByLineage(assignment),
+                    ...(params.generationRun?.variantIndex !== undefined ? { variantIndex: params.generationRun.variantIndex } : {}),
                     mediaModelId,
                 },
             }
@@ -822,10 +910,12 @@ export async function upsertGeneratedImageToCanvas(params: UpsertImageInput): Pr
             nextState = { ...nextState, nodes: nodeResult.nodes }
             const edgeResult = addGeneratedMediaEdge(nextState, lineageParentNodeId, nodeId)
             nextState = edgeResult.state
+            const rebalanceResult = rebalanceGeneratedMediaChildren(nextState, lineageParentNodeId)
+            nextState = rebalanceResult.state
             const collisionResult = resolveCanvasProjectionCollisions(nextState, 'upsertGeneratedImageToCanvas')
             return {
                 canvasState: collisionResult.state,
-                changed: markerResult.changed || nodeResult.changed || edgeResult.changed || collisionResult.changed,
+                changed: markerResult.changed || nodeResult.changed || edgeResult.changed || rebalanceResult.changed || collisionResult.changed,
             }
         },
     })
@@ -872,6 +962,7 @@ export async function upsertGeneratedVideoToCanvas(params: UpsertVideoInput): Pr
                     aspectRatio: params.aspectRatio,
                     hasAudio: params.hasAudio,
                     ...generatedByLineage(assignment),
+                    ...(params.generationRun?.variantIndex !== undefined ? { variantIndex: params.generationRun.variantIndex } : {}),
                     ...(params.generationRun?.mediaModelId ? { mediaModelId: params.generationRun.mediaModelId } : {}),
                 },
             }
@@ -879,10 +970,12 @@ export async function upsertGeneratedVideoToCanvas(params: UpsertVideoInput): Pr
             nextState = { ...nextState, nodes: nodeResult.nodes }
             const edgeResult = addGeneratedMediaEdge(nextState, lineageParentNodeId, nodeId)
             nextState = edgeResult.state
+            const rebalanceResult = rebalanceGeneratedMediaChildren(nextState, lineageParentNodeId)
+            nextState = rebalanceResult.state
             const collisionResult = resolveCanvasProjectionCollisions(nextState, 'upsertGeneratedVideoToCanvas')
             return {
                 canvasState: collisionResult.state,
-                changed: markerResult.changed || nodeResult.changed || edgeResult.changed || collisionResult.changed,
+                changed: markerResult.changed || nodeResult.changed || edgeResult.changed || rebalanceResult.changed || collisionResult.changed,
             }
         },
     })


### PR DESCRIPTION
## Summary

- Harden `resolveCollisions` (`packages/lixpi/canvas-engine`) against non-finite/negative `iterations`, `margin`, `overlapThreshold`, `width`, and `height` inputs so invalid box geometry can no longer corrupt layout.
- Preserve API-owned media lineage (branch origin/fork/line markers and generated image/video nodes) when a full canvas-state save comes from the browser. `Workspace.updateCanvasState` now merges the incoming state against the canonical stored state, protecting freshly generated media nodes for a grace window and keeping their edges/markers intact.
- Add `reasoningIndex`/`mediaIndex` ordering to lineage assignments and use it to rebalance generated-media sibling node positions deterministically, and prune stale marker edges when a generated media node's edge is replaced.

## Why

Concurrent browser saves could clobber API-authored lineage data, and unguarded numeric inputs to the collision resolver could produce invalid geometry.

Closes #295