### PR TITLE
LIX-299 # Decouple SidePanel outside-close from overlay element and add test coverage

### DIFF
--- a/services/web-ui/src/components/sidePanel/README.md
+++ b/services/web-ui/src/components/sidePanel/README.md
@@ -16,9 +16,11 @@ The translucent glass backdrop is a feature of this component — its element an
 
 ## Background Overlay
 
-The background overlay is optional and controlled by `overlay.enabled`. It is separate from the glass backdrop: `overlayElement` visually covers the host container behind the side panel while `backdropElement` stays panel-width and glassy. The overlay uses a dark tint with a low-intensity distortion filter — `backdrop-filter: blur(4px) saturate(108%)`, WebKit fallback, and a reduced-transparency fallback. Overlay pointer hit-testing stays transparent so drag movement reaches the host pan surface; document-level capture requests close on click/tap when `overlay.closeOnPointerDown` is enabled and blocks that click from leaking through.
+The background overlay is an optional visual surface controlled by `overlay.enabled`. It is separate from the glass backdrop: `overlayElement` visually covers the host container behind the side panel while `backdropElement` stays panel-width and glassy. The overlay uses a dark tint with a low-intensity distortion filter: `backdrop-filter: blur(4px) saturate(108%)`, WebKit fallback, and a reduced-transparency fallback.
 
-Overlay close ignores the mounted panel, the toggle, the resize handle, and any target inside `[data-side-panel-no-drag]`. Body-mounted popovers and menus launched from the panel should use that attribute so their option clicks run instead of collapsing the drawer first.
+Outside click/tap close is controlled by `overlay.closeOnPointerDown`. It works whether or not the visual overlay element is enabled. When `overlayElement` exists, the close region is the overlay bounds; otherwise the close region is the viewport. Document-level capture handles the request and blocks the final click from leaking through, while pointer drag movement still reaches the host pan surface.
+
+Outside close ignores the mounted panel, the toggle, the resize handle, and any target inside `[data-side-panel-no-drag]`. Body-mounted popovers and menus launched from the panel should use that attribute so their option clicks run instead of collapsing the drawer first.
 
 ## Open / close animation
 
@@ -66,7 +68,7 @@ The component owns the panel width state, clamps it through the configured const
 - `styles`: optional `gradient` and `width` overrides for the resize-handle line.
 - `toggle`: optional component-owned open/collapse button config: SVG markup, ARIA labels, positioning offsets, travel distance, motion mode, class name, and `onToggle()`. `motion: 'slide'` is the default; `motion: 'fixed'` keeps the toggle anchored while panel surfaces open under it.
 - `animation`: optional slide `durationMs`, `openEasing`, `closeEasing`, and fallback `easing`.
-- `overlay`: optional background overlay config: `enabled`, `fill`, `fillOpaque`, `opacity`, `className`, and `closeOnPointerDown`.
+- `overlay`: optional overlay and outside-close config. `enabled` controls the visual overlay element; `fill`, `fillOpaque`, `opacity`, and `className` style that element; `closeOnPointerDown` controls outside click/tap close.
 - `drag`: optional swipe-to-close config: `enabled`, `closeThreshold`, `velocityThreshold`, `pointerSwipeStartThreshold`, and `touchSwipeStartThreshold`.
 - `minWidth`, `defaultWidth`: resize constraints. `defaultWidth` is the resolved width before the user has ever resized.
 - `getMaxWidth()`: dynamic upper bound (depends on available canvas/pane width).
@@ -112,4 +114,4 @@ Pass `className` to add panel-specific resize-handle overrides without touching 
 
 ## Cleanup
 
-`detachPanel()` removes panel-owned resize-handle/backdrop/overlay DOM and cancels any in-flight slide cleanup while leaving the toggle available for reopening. `destroy()` removes every mounted element and listener, including the global `pointermove` / `pointerup` / `pointercancel` listeners added during an active resize and the mounted-panel pointer listeners added for swipe-to-close. It leaves the host panel and any host-owned state untouched.
+`detachPanel()` removes panel-owned resize-handle/backdrop/overlay DOM and cancels any in-flight slide cleanup while leaving the toggle available for reopening. `destroy()` removes every mounted element and listener, including the global `pointermove` / `pointerup` / `pointercancel` listeners added during an active resize, the document-level outside-close listeners, and the mounted-panel pointer listeners added for swipe-to-close. It leaves the host panel and any host-owned state untouched.

--- a/services/web-ui/src/components/sidePanel/sidePanel.test.ts
+++ b/services/web-ui/src/components/sidePanel/sidePanel.test.ts
@@ -846,6 +846,88 @@ describe('SidePanel', () => {
         sidePanel.destroy()
     })
 
+    it('closes from an outside click across the full viewport when the overlay element is disabled', () => {
+        const onOpenChange = vi.fn()
+        const sidePanel = createSidePanel(buildConfig({
+            overlay: {
+                enabled: false,
+                closeOnPointerDown: true,
+            },
+            onOpenChange,
+        }))
+
+        expect(sidePanel.overlayElement).toBeNull()
+        sidePanel.setOpen(true)
+
+        overlayPointerDown(200, 200)
+        overlayClick(200, 200)
+        expect(onOpenChange).toHaveBeenCalledExactlyOnceWith(false)
+
+        sidePanel.destroy()
+    })
+
+    it('ignores outside clicks on the panel, toggle, or resize handle when the overlay element is disabled', () => {
+        const onOpenChange = vi.fn()
+        const sidePanel = createSidePanel(buildConfig({
+            overlay: {
+                enabled: false,
+                closeOnPointerDown: true,
+            },
+            toggle: {
+                iconSvg: '<svg></svg>',
+                openAriaLabel: 'Collapse panel',
+                closedAriaLabel: 'Open panel',
+                onToggle: vi.fn(),
+            },
+            onOpenChange,
+        }))
+        const panel = document.createElement('div')
+        document.body.appendChild(panel)
+        sidePanel.mountOpen(panel)
+        sidePanel.setOpen(true)
+
+        overlayPointerDown(200, 200, { target: panel })
+        overlayClick(200, 200, { target: panel })
+        expect(onOpenChange).not.toHaveBeenCalled()
+
+        overlayPointerDown(200, 200, { target: sidePanel.toggleElement as HTMLElement })
+        overlayClick(200, 200, { target: sidePanel.toggleElement as HTMLElement })
+        expect(onOpenChange).not.toHaveBeenCalled()
+
+        overlayPointerDown(200, 200, { target: sidePanel.element })
+        overlayClick(200, 200, { target: sidePanel.element })
+        expect(onOpenChange).not.toHaveBeenCalled()
+
+        sidePanel.destroy()
+    })
+
+    it('does not wire outside-close listeners when overlay config is entirely absent', () => {
+        const onOpenChange = vi.fn()
+        const sidePanel = createSidePanel(buildConfig({ onOpenChange }))
+
+        sidePanel.setOpen(true)
+        overlayPointerDown(900, 900)
+        overlayClick(900, 900)
+        expect(onOpenChange).not.toHaveBeenCalled()
+
+        sidePanel.destroy()
+    })
+
+    it('removes document-level outside-close listeners on destroy even without an overlay element', () => {
+        const onOpenChange = vi.fn()
+        const sidePanel = createSidePanel(buildConfig({
+            overlay: { enabled: false, closeOnPointerDown: true },
+            onOpenChange,
+        }))
+        sidePanel.setOpen(true)
+
+        sidePanel.destroy()
+
+        overlayPointerDown(900, 900)
+        overlayClick(900, 900)
+        expect(onOpenChange).not.toHaveBeenCalled()
+    })
+
     it('does not start swipe-close gestures from interactive or opted-out panel children', () => {
         const onOpenChange = vi.fn()
         const sidePanel = createSidePanel(buildConfig({

--- a/services/web-ui/src/components/sidePanel/sidePanel.ts
+++ b/services/web-ui/src/components/sidePanel/sidePanel.ts
@@ -60,6 +60,9 @@ export type SidePanelAnimationConfig = {
 }
 
 export type SidePanelOverlayConfig = {
+    // Visual overlay surface. Outside click/tap close is controlled separately
+    // by `closeOnPointerDown` so hosts can keep the close behavior without
+    // drawing or mounting an overlay element.
     enabled: boolean
     className?: string
     fill?: string
@@ -206,7 +209,7 @@ type PanelDragState = {
     lastEvent: PointerEvent
 }
 
-type OverlayPointerStart = {
+type OutsidePointerStart = {
     clientX: number
     clientY: number
 }
@@ -227,7 +230,7 @@ class SidePanel implements SidePanelInstance {
     private finishSlideWait: (() => void) | null = null
     private isOpen = false
     private panelDragState: PanelDragState | null = null
-    private overlayPointerStart: OverlayPointerStart | null = null
+    private outsidePointerStart: OutsidePointerStart | null = null
     private closeFromCurrentTransforms = false
 
     constructor(private readonly config: SidePanelConfig) {
@@ -273,9 +276,9 @@ class SidePanel implements SidePanelInstance {
         this.applyAnimationSettings(this.backdropElement)
         if (this.overlayElement) this.applyOverlaySettings(this.overlayElement)
         if (this.toggleElement) this.applyAnimationSettings(this.toggleElement)
-        if (this.overlayElement) {
-            document.addEventListener('pointerdown', this.handleOverlayPointerDown, true)
-            document.addEventListener('click', this.handleOverlayClick, true)
+        if (this.isOutsideCloseEnabled()) {
+            document.addEventListener('pointerdown', this.handleOutsidePointerDown, true)
+            document.addEventListener('click', this.handleOutsideClick, true)
         }
         this.setOpen(false)
         if (this.toggleElement) {
@@ -362,6 +365,10 @@ class SidePanel implements SidePanelInstance {
             ? opacity
             : OVERLAY_DEFAULT_OPACITY
     }
+
+    private isOutsideCloseEnabled = (): boolean => Boolean(
+        this.config.overlay && this.config.overlay.closeOnPointerDown !== false
+    )
 
     // Resolve the width to start a drag from. Prefer the stored width; otherwise
     // measure the actual rendered panel, falling back to the resolved default.
@@ -477,31 +484,29 @@ class SidePanel implements SidePanelInstance {
         this.config.toggle?.onToggle()
     }
 
-    private handleOverlayPointerDown = (event: PointerEvent): void => {
-        this.overlayPointerStart = null
+    private handleOutsidePointerDown = (event: PointerEvent): void => {
+        this.outsidePointerStart = null
         if (!this.isOpen) return
-        if (this.config.overlay?.closeOnPointerDown === false) return
         if (event.button !== 0 || event.isPrimary === false) return
-        if (!this.isEventInsideOverlay(event)) return
-        if (this.shouldIgnoreOverlayCloseTarget(event.target)) return
-        this.overlayPointerStart = {
+        if (!this.isEventInsideOutsideCloseRegion(event)) return
+        if (this.shouldIgnoreOutsideCloseTarget(event.target)) return
+        this.outsidePointerStart = {
             clientX: event.clientX,
             clientY: event.clientY,
         }
     }
 
-    private handleOverlayClick = (event: MouseEvent): void => {
+    private handleOutsideClick = (event: MouseEvent): void => {
         if (!this.isOpen) return
-        if (this.config.overlay?.closeOnPointerDown === false) return
         if (event.button !== 0) return
-        if (!this.isEventInsideOverlay(event)) return
-        if (this.shouldIgnoreOverlayCloseTarget(event.target)) return
+        if (!this.isEventInsideOutsideCloseRegion(event)) return
+        if (this.shouldIgnoreOutsideCloseTarget(event.target)) return
 
         event.preventDefault()
         event.stopPropagation()
 
-        const start = this.overlayPointerStart
-        this.overlayPointerStart = null
+        const start = this.outsidePointerStart
+        this.outsidePointerStart = null
         if (start) {
             const distance = Math.hypot(event.clientX - start.clientX, event.clientY - start.clientY)
             if (distance > OVERLAY_CLICK_DISTANCE) return
@@ -510,9 +515,9 @@ class SidePanel implements SidePanelInstance {
         this.config.onOpenChange?.(false)
     }
 
-    private isEventInsideOverlay = (event: MouseEvent | PointerEvent): boolean => {
-        if (!this.overlayElement) return false
-        const rect = this.overlayElement.getBoundingClientRect()
+    private isEventInsideOutsideCloseRegion = (event: MouseEvent | PointerEvent): boolean => {
+        const rect = this.overlayElement?.getBoundingClientRect()
+            ?? { left: 0, top: 0, right: window.innerWidth, bottom: window.innerHeight }
         return (
             event.clientX >= rect.left &&
             event.clientX <= rect.right &&
@@ -521,7 +526,7 @@ class SidePanel implements SidePanelInstance {
         )
     }
 
-    private shouldIgnoreOverlayCloseTarget = (target: EventTarget | null): boolean => {
+    private shouldIgnoreOutsideCloseTarget = (target: EventTarget | null): boolean => {
         if (!(target instanceof Node)) return false
         const targetElement = target instanceof Element ? target : target.parentElement
         if (targetElement?.closest(SIDE_PANEL_INTERACTION_BLOCK_SELECTOR)) return true
@@ -877,9 +882,9 @@ class SidePanel implements SidePanelInstance {
         this.animatedPanel = null
         this.listeners.clear()
         this.element.removeEventListener('pointerdown', this.handleResizeStart)
-        if (this.overlayElement) {
-            document.removeEventListener('pointerdown', this.handleOverlayPointerDown, true)
-            document.removeEventListener('click', this.handleOverlayClick, true)
+        if (this.isOutsideCloseEnabled()) {
+            document.removeEventListener('pointerdown', this.handleOutsidePointerDown, true)
+            document.removeEventListener('click', this.handleOutsideClick, true)
         }
         this.toggleElement?.remove()
     }

--- a/services/web-ui/src/settings.ts
+++ b/services/web-ui/src/settings.ts
@@ -921,7 +921,9 @@ export const settings: Settings = {
             closeEasing: 'cubic-bezier(0.64, 0, 0.78, 0)',
         },
         overlay: {
-            // The workspace list should not dim or intercept the canvas behind it.
+            // The visual overlay is disabled so the workspace list does not dim
+            // the canvas. `closeOnPointerDown` still collapses the panel from
+            // document-level outside clicks.
             enabled: false,
             closeOnPointerDown: true,
             fill: 'rgba(15, 23, 42, 0.18)',


### PR DESCRIPTION
## Summary

- Decouples outside click/tap close (`overlay.closeOnPointerDown`) from the visual overlay element (`overlay.enabled`) in `SidePanel`. Outside-close now falls back to the viewport as the close region when the overlay element is not mounted.
- Adds test coverage for the previously-uncovered overlay-disabled outside-close behavior: viewport-wide close, ignored panel/toggle/resize-handle targets, absent `overlay` config, and destroy cleanup.
- Updates the component README to describe the decoupled behavior.

Closes #299

## Test plan

- [x] `docker compose --profile dev --profile main run --rm --no-deps -T lixpi-typescript-test-runner web-ui src/components/sidePanel/sidePanel.test.ts` — 39/39 passing
- [x] `docker compose --profile dev --profile main run --rm --no-deps -T lixpi-typescript-test-runner web-ui` — full suite, 1391/1391 passing