### PR TITLE
LIX-301 # Eliminate DynamoDB GSIs, make multi-table writes transactional, remove document revisions

### DIFF
--- a/documentation/README.md
+++ b/documentation/README.md
@@ -42,6 +42,7 @@ The cross-cutting spine. Every feature references these instead of re-explaining
 | [System Architecture](platform/SYSTEM-ARCHITECTURE.md) | Service responsibilities, NATS as the backbone, subject conventions, design decisions, scaling |
 | [AI Generation Pipeline](platform/AI-GENERATION-PIPELINE.md) | The shared LangGraph workflow, `ProviderState`, the post-stream 3-way router, dual-model routing, tool injection/extraction, `ImageRouter`/`VideoRouter`, stream lifecycle, usage |
 | [Streaming & Events](platform/STREAMING-AND-EVENTS.md) | Live AI pipeline subjects, JetStream replay logs, ProseMirror step streams, and the stream-event catalog |
+| [Data Storage](platform/DATA-STORAGE.md) | DynamoDB table layout, the Main/Meta/Access-List triad, scope-partitioned keys, the transactional multi-table write rule, and the object-store split |
 | [Authentication](platform/AUTHENTICATION.md) | Dual auth model, NATS auth callout, `@lixpi/auth-service`, LocalAuth0 |
 | [Nano Stores](platform/NANOSTORES.md) | Browser-side store conventions for `nanostores`, persistent stores, and framework-agnostic TypeScript consumers |
 | [Infrastructure Overview](platform/deployment/INFRASTRUCTURE-OVERVIEW.md) | Pulumi, AWS topology, network, ECS `api`, web-ui delivery, DynamoDB |

--- a/documentation/library/WORKSPACE-EXPORT-IMPORT.md
+++ b/documentation/library/WORKSPACE-EXPORT-IMPORT.md
@@ -51,7 +51,7 @@ workspace-export.zip
         canvasStateUpdatedAt: number,   // Canvas save token
         updatedAt: number,
     },
-    documents: Document[],             // All documents (latest revisions)
+    documents: Document[],             // All documents in the workspace
     aiChatThreads: AiChatThread[],     // All AI chat threads with messages
 }
 ```

--- a/documentation/platform/DATA-STORAGE.md
+++ b/documentation/platform/DATA-STORAGE.md
@@ -1,0 +1,172 @@
+---
+title: Data Storage
+description: How Lixpi persists workspaces and every item they surface — the DynamoDB table layout, the Main/Meta/Access-List triad, scope-partitioned keys, the transactional multi-table write rule, and where binary bytes live in the NATS JetStream Object Store.
+---
+
+# Data Storage
+
+This page explains where each kind of item a user sees inside a workspace lives, how those records are keyed, and how binary media is stored separately from structured metadata. It complements the [Workspace Model](../canvas/WORKSPACE-MODEL.md), [Feature Storage](../library/FEATURE-STORAGE.md), and [Media Library](../library/MEDIA-LIBRARY.md) pages, which each go deeper on one item type; this page is the cross-cutting view of the persistence layer.
+
+Fact-check anything here against the models in [`services/api/src/models/`](../../services/api/src/models), the shared access layer in [`packages/lixpi/dynamodb-service/`](../../packages/lixpi/dynamodb-service), and the table definitions in [`infrastructure/pulumi/src/resources/db/DynamoDB-tables.ts`](../../infrastructure/pulumi/src/resources/db/DynamoDB-tables.ts) before repeating it.
+
+## Two-Tier Storage
+
+Every item splits into **structured metadata** and **binary bytes**, held in two different systems.
+
+| Storage | Technology | What it holds |
+|---------|-----------|---------------|
+| **DynamoDB** | AWS DynamoDB (DynamoDB Local in development) | Structured records: workspaces, canvas state, documents, chat threads, features, extraction runs, and the file IDs that reference binary assets |
+| **Object Store** | NATS JetStream Object Store | Binary bytes: uploaded files, generated images and videos, posters, media-library assets |
+
+DynamoDB records store only the **keys** that address objects in the object store (a canvas image node's `fileId`, a workspace's inline `files[]` registry, a feature's `sampleImages[].fileId`). The raw bytes are never stored in DynamoDB.
+
+The DynamoDB access layer is a single shared class, [`DynamoDBService`](../../packages/lixpi/dynamodb-service/src/dynamodb-service.ts), used by every model through a global `dynamoDBService`. Physical table names are computed by `getDynamoDbTableStageName('LOGICAL_NAME', ORG_NAME, STAGE)`, which maps a logical key to a stage-scoped physical name such as `Workspaces-<org>-<stage>`. Tables use `PAY_PER_REQUEST` billing, and outside a custom local provider they enable DynamoDB Streams with `NEW_AND_OLD_IMAGES`.
+
+## Keying Rules
+
+Two rules govern how tables are keyed and written. They are the contract for any new item type.
+
+### The Partition Key Is the Thing You List By
+
+If an access pattern lists items within a scope, the table serving that list is partitioned by that scope. Listing a workspace's documents is `Query(Documents, workspaceId = ...)`; listing an organization's media is `Query(Media-Library-Items-Meta, scopeAndOwner = ...)`. Every list read is a single-partition `Query` — never a full-table `Scan` (the one deliberate exception is `Extraction-Runs`, whose tiny volume suits a scan) and never a secondary index.
+
+The canonical pattern is `AI-Chat-Threads`: PK `workspaceId`, SK `threadId`. Point operations address a row with the scope id plus the item id, both of which every caller carries.
+
+{% callout type="warning" %}
+Do not add DynamoDB Global Secondary Indexes. A GSI is a second physical copy of the table with its own write capacity, its own eventual-consistency lag, and its own failure mode — a write that lands in the base table but not yet in the index produces a stale list. If a list query seems to need a GSI, the base-table key is wrong: partition the table by the scope instead. Reach for a GSI only if it is absolutely essential and no key redesign can serve the access pattern — and treat that as a design escalation, not a default. Local Secondary Indexes are acceptable; they share the base table's partition key and carry none of the second-copy cost.
+{% /callout %}
+
+Range keys are immutable ids. Never put a mutable attribute (such as `updatedAt`) in a primary key — every update would become a delete-plus-put with a partial-failure window. Recency ordering is an in-memory sort over an already-small partition.
+
+### More Than One Table Modified Means One Transaction
+
+Any model method that writes to two or more tables issues exactly one `transactWrite` call — the typed transaction API on `DynamoDBService` that accepts the same operation shapes as `putItem` / `updateItem` / `deleteItems` and commits up to 100 actions atomically. Either every row of the Main / Meta / Access-List triad lands, or none does.
+
+Sequential awaits across tables, and compensating rollbacks that imitate atomicity, are both forbidden shapes; a reviewer can reject any diff that contains either. Single-table operations stay on the non-transactional methods — a transaction of one item buys nothing.
+
+Per-item conditions still work inside a transaction (canvas saves keep their optimistic-concurrency `conditionExpression`); a failed condition cancels the whole transaction and surfaces through `isTransactionConditionalCheckFailure`, which the retry loops check.
+
+## The Workspace Is a Peer, Not a Physical Container
+
+In the UI a workspace feels like a folder that holds documents, threads, and media. In storage it is not a nested container:
+
+- The **workspace record** is one DynamoDB item that embeds the canvas (`viewport`, `nodes[]`, `edges[]`) and a `files[]` reference registry inline.
+- **Documents, AI chat threads, and extraction runs** live in their own tables, scoped to their workspace.
+- **Media-library items and features** are **organization-scoped**. They record which workspace they originated from (`originWorkspaceId` / `workspaceId`) but are readable across every workspace in the owning organization.
+
+## Entity Relationships
+
+```mermaid
+%%{init: {'theme': 'base', 'themeVariables': { 'primaryColor': '#F6C7B3', 'primaryTextColor': '#5a3a2a', 'primaryBorderColor': '#d4956a', 'secondaryColor': '#C3DEDD', 'secondaryTextColor': '#1a3a47', 'secondaryBorderColor': '#4a8a9d', 'tertiaryColor': '#DCECE9', 'tertiaryTextColor': '#1a3a47', 'tertiaryBorderColor': '#82B2C0', 'lineColor': '#d4956a', 'textColor': '#5a3a2a'}}}%%
+graph TB
+    subgraph OrgScope["Organization scope"]
+        Org["Organization"]
+        MediaLib["Media Library Items<br/>meta partitioned by scopeAndOwner"]
+        Features["Features<br/>meta partitioned by scopeAndOwner"]
+    end
+
+    subgraph WsScope["Workspace scope"]
+        WS["Workspace<br/>canvasState and files inline"]
+        Docs["Documents<br/>partitioned by workspaceId"]
+        Threads["AI Chat Threads<br/>key workspaceId + threadId"]
+        Runs["Extraction Runs<br/>scan-filtered by workspaceId"]
+    end
+
+    subgraph Bytes["Binary bytes"]
+        WSBucket[("workspace-id-files")]
+        MLBucket[("media-library-org-id-files")]
+    end
+
+    Org --> WS
+    Org --> MediaLib
+    Org --> Features
+    WS --> Docs
+    WS --> Threads
+    WS --> Runs
+    WS -.->|originWorkspaceId| MediaLib
+    WS -.->|workspaceId of origin| Features
+
+    WS -->|fileId references| WSBucket
+    MediaLib -->|asset keys| MLBucket
+    Features -.->|sample fileId| MLBucket
+```
+
+## The Main / Meta / Access-List Triad
+
+Most item types split across three tables so that listing a sidebar never reads a heavy body.
+
+| Table role | Suffix | Holds |
+|------------|--------|-------|
+| Main | (none) | The full heavy record — content, canvas state, instructions |
+| Meta | `-Meta` | A lightweight projection (name, title, timestamps, preview key) for list views |
+| Access list | `-Access-List` | Who can see the item, keyed by user or principal |
+
+Creates fan out to all three tables in a single transaction: `createWorkspace` writes `Workspaces`, `Workspaces-Meta`, and `Workspaces-Access-List` as one `transactWrite`, and the media-library and feature creates do the same for their triads.
+
+Where a Meta table serves the org-scoped list, it is the table partitioned by the scope (`scopeAndOwner` = `${scope}#${scopeOwnerId}`), and it carries the projection fields list views and save-time dedup need — the Main table stays a pure point-access body store.
+
+## Per-Item Storage
+
+### Workspace
+
+Defined in [`models/workspace.ts`](../../services/api/src/models/workspace.ts). Tables: `Workspaces` / `Workspaces-Meta` / `Workspaces-Access-List`.
+
+- Key: `workspaceId` (hash only).
+- Embeds `canvasState` (`{ viewport, nodes[], edges[] }`) and a `files[]` array of `DocumentFile` references directly in the item.
+- Canvas writes use optimistic concurrency. A `canvasStateUpdatedAt` token guards every write through a DynamoDB `conditionExpression` inside the Main+Meta transaction; a stale token returns `STALE_CANVAS_STATE`. `mutateCanvasState` retries up to five times on a conditional-check failure.
+- `addFile` uses an atomic `list_append` so concurrent AI-generated images do not clobber each other. `removeFile` and `setFileCanonical` use read-modify-write with conditional retries. These are single-table writes and stay non-transactional.
+- `mergeApiLineageForFullCanvasSave` protects API-generated media nodes and branch-marker nodes from being dropped by a full client canvas save. See [API-Owned Media Lineage Planning](../knowledge/API-OWNED-MEDIA-LINEAGE-PLANNING.md).
+
+### Documents
+
+Defined in [`models/document.ts`](../../services/api/src/models/document.ts). Tables: `Documents` / `Documents-Meta` / `Documents-Access-List`.
+
+- Key: `workspaceId` (hash) + `documentId` (range) — one row per document. "All documents in this workspace" is one partition `Query` returning full bodies.
+- `Documents-Meta` stays keyed by `documentId` alone so tag operations, whose payloads carry only the document id, address it directly.
+- Delete removes the Main row and the Meta row in one transaction.
+- ProseMirror content is stored inline as `content`.
+
+### AI Chat Threads
+
+Defined in [`models/ai-chat-thread.ts`](../../services/api/src/models/ai-chat-thread.ts). Table: `AI-Chat-Threads`.
+
+- Composite key `workspaceId` (hash) + `threadId` (range), so a workspace's threads are a single efficient query. No separate meta table.
+- Stores ProseMirror `content`, `aiModel`, and a `status` field.
+
+### Media Library Items
+
+Defined in [`models/media-library-item.ts`](../../services/api/src/models/media-library-item.ts). Tables: `Media-Library-Items` / `Media-Library-Items-Meta` / `Media-Library-Items-Access-List`.
+
+- Main key: `itemId` (hash) + `version` (range) — point access only.
+- Meta key: `scopeAndOwner` (hash, `organization#<orgId>`) + `itemId` (range). The meta partition serves both the library list and save-time dedup: the projection carries `sourceFileId`, so re-saving the same source file finds the existing meta row and point-reads the body instead of duplicating the item.
+- Records are kind-discriminated (`image`, `video`, `audio`, `document`) and carry `originWorkspaceId` for provenance. See [Media Library](../library/MEDIA-LIBRARY.md).
+
+### Features
+
+Defined in [`models/feature.ts`](../../services/api/src/models/feature.ts). Tables: `Features` / `Features-Meta` / `Features-Access-List`.
+
+- Main key: `featureId` (hash) + `version` (range) — point access only.
+- Meta key: `scopeAndOwner` (hash) + `featureId` (range). Listing an organization's features queries the meta partition and sorts by `updatedAt` in memory.
+- Records the origin `workspaceId` only; reads are allowed for any member of the owning organization. See [Feature Storage](../library/FEATURE-STORAGE.md).
+
+### Extraction Runs
+
+Defined in [`models/extraction-run.ts`](../../services/api/src/models/extraction-run.ts). Table: `Extraction-Runs`.
+
+- Key: `extractionRunId` (hash) + `workspaceId` (range). Listing a workspace's runs does a full table scan filtered in memory, which suits the run volume.
+- Accumulates streaming state through incremental updates: `transcriptJson`, `stageReasoning`, a `trace[]` event log, and the final `featureCard`.
+
+## Where the Binary Bytes Live
+
+Binary content is stored in NATS JetStream Object Store buckets, not in DynamoDB and not in S3.
+
+| Bucket | Named by | Created |
+|--------|----------|---------|
+| `workspace-<workspaceId>-files` | `Workspace.getBucketName` | With the workspace lifecycle |
+| `media-library-<scope>-<scopeOwnerId>-files` | `getMediaLibraryBucketName` in [`services/media-library-storage.ts`](../../services/api/src/services/media-library-storage.ts) | Lazily, on the first save into an organization |
+
+DynamoDB records store the file IDs that address objects in these buckets. Deleting a workspace tears down both its DynamoDB records and its object-store bucket.
+
+{% callout type="note" %}
+The object store is part of the NATS backbone. For how buckets are opened, created, and replicated, see [System Architecture](SYSTEM-ARCHITECTURE.md) and the storage sections of [Video Generation](../media-generation/VIDEO-GENERATION.md).
+{% /callout %}

--- a/documentation/platform/deployment/INFRASTRUCTURE-OVERVIEW.md
+++ b/documentation/platform/deployment/INFRASTRUCTURE-OVERVIEW.md
@@ -341,7 +341,7 @@ Highlights:
 | `USERS` | `userId` | — | |
 | `WORKSPACES` / `WORKSPACES_META` | `workspaceId` | — | Split for hot canvas state vs cold meta |
 | `WORKSPACES_ACCESS_LIST` | `userId / workspaceId` | LSI on createdAt, updatedAt | |
-| `DOCUMENTS` | `documentId / revision` | GSI on `workspaceId`, TTL `revisionExpiresAt` | Versioned documents |
+| `DOCUMENTS` | `workspaceId / documentId` | LSI on createdAt, updatedAt | Documents partitioned by workspace |
 | `AI_CHAT_THREADS` | `workspaceId / threadId` | LSI on createdAt | Threads scoped per workspace |
 | `AI_TOKENS_USAGE_TRANSACTIONS` | `userId / transactionProcessedAt` | LSI x4 (document, model, org, formatted date) | Usage ledger |
 | `FINANCIAL_TRANSACTIONS` | `userId / transactionId` | LSI on status, createdAt, provider | Billing |

--- a/infrastructure/pnpm-workspace.yaml
+++ b/infrastructure/pnpm-workspace.yaml
@@ -5,6 +5,7 @@ packages:
 
 allowBuilds:
   "@pulumi/aws": true
+  "protobufjs": true
   "@pulumi/command": true
   "@pulumi/docker-build": true
   "@pulumi/pulumi": true

--- a/infrastructure/pulumi/src/resources/db/DynamoDB-tables.ts
+++ b/infrastructure/pulumi/src/resources/db/DynamoDB-tables.ts
@@ -82,21 +82,16 @@ export const getTableDefinitions = () => [
     {
         name: getDynamoDbTableStageName('DOCUMENTS', ORG_NAME, STAGE),
         attributes: [
-            { name: 'documentId', type: 'S' as const },
-            { name: 'revision', type: 'N' as const },
-            { name: 'createdAt', type: 'N' as const },
             { name: 'workspaceId', type: 'S' as const },
+            { name: 'documentId', type: 'S' as const },
+            { name: 'createdAt', type: 'N' as const },
         ],
-        hashKey: 'documentId',
-        rangeKey: 'revision',
+        hashKey: 'workspaceId',
+        rangeKey: 'documentId',
         localSecondaryIndexes: [
             { name: 'createdAt', rangeKey: 'createdAt', projectionType: 'ALL' as const },
             { name: 'updatedAt', rangeKey: 'createdAt', projectionType: 'ALL' as const },
         ],
-        globalSecondaryIndexes: [
-            { name: 'workspaceId', hashKey: 'workspaceId', projectionType: 'ALL' as const },
-        ],
-        ttl: { attributeName: 'revisionExpiresAt', enabled: true },
     },
     {
         name: getDynamoDbTableStageName('DOCUMENTS_META', ORG_NAME, STAGE),
@@ -193,26 +188,18 @@ export const getTableDefinitions = () => [
         attributes: [
             { name: 'itemId', type: 'S' as const },
             { name: 'version', type: 'N' as const },
-            { name: 'scopeAndOwner', type: 'S' as const },
-            { name: 'updatedAt', type: 'N' as const },
         ],
         hashKey: 'itemId',
         rangeKey: 'version',
-        globalSecondaryIndexes: [
-            { name: 'scopeAndOwner', hashKey: 'scopeAndOwner', rangeKey: 'updatedAt', projectionType: 'ALL' as const },
-        ],
     },
     {
         name: getDynamoDbTableStageName('MEDIA_LIBRARY_ITEMS_META', ORG_NAME, STAGE),
         attributes: [
-            { name: 'itemId', type: 'S' as const },
             { name: 'scopeAndOwner', type: 'S' as const },
-            { name: 'updatedAt', type: 'N' as const },
+            { name: 'itemId', type: 'S' as const },
         ],
-        hashKey: 'itemId',
-        globalSecondaryIndexes: [
-            { name: 'scopeAndOwner', hashKey: 'scopeAndOwner', rangeKey: 'updatedAt', projectionType: 'ALL' as const },
-        ],
+        hashKey: 'scopeAndOwner',
+        rangeKey: 'itemId',
     },
     {
         name: getDynamoDbTableStageName('MEDIA_LIBRARY_ITEMS_ACCESS_LIST', ORG_NAME, STAGE),
@@ -232,19 +219,18 @@ export const getTableDefinitions = () => [
         attributes: [
             { name: 'featureId', type: 'S' as const },
             { name: 'version', type: 'N' as const },
-            { name: 'scopeAndOwner', type: 'S' as const },
-            { name: 'updatedAt', type: 'N' as const },
         ],
         hashKey: 'featureId',
         rangeKey: 'version',
-        globalSecondaryIndexes: [
-            { name: 'byScopeAndOwner', hashKey: 'scopeAndOwner', rangeKey: 'updatedAt', projectionType: 'ALL' as const },
-        ],
     },
     {
         name: getDynamoDbTableStageName('FEATURES_META', ORG_NAME, STAGE),
-        attributes: [{ name: 'featureId', type: 'S' as const }],
-        hashKey: 'featureId',
+        attributes: [
+            { name: 'scopeAndOwner', type: 'S' as const },
+            { name: 'featureId', type: 'S' as const },
+        ],
+        hashKey: 'scopeAndOwner',
+        rangeKey: 'featureId',
     },
     {
         name: getDynamoDbTableStageName('FEATURES_ACCESS_LIST', ORG_NAME, STAGE),

--- a/packages/lixpi/constants/ts/types.ts
+++ b/packages/lixpi/constants/ts/types.ts
@@ -1223,6 +1223,7 @@ export type FeatureMeta = {
     scopeOwnerId: string
     status: FeatureStatus
     ownerUserId: string
+    scopeAndOwner?: string    // PK of the Features-Meta table — `${scope}#${scopeOwnerId}`; present on persisted rows
     sampleZeroKey?: string
     sampleZeroUrl?: string
     updatedAt: number
@@ -1324,6 +1325,7 @@ export type MediaLibraryImageMeta = {
     displayName: string
     ownerUserId: string
     originWorkspaceId: string
+    sourceFileId?: string         // source object key — lets save-time dedup query the meta partition
     scope: MediaLibraryScope
     scopeOwnerId: string
     scopeAndOwner: string
@@ -1378,6 +1380,7 @@ export type MediaLibraryVideoMeta = {
     displayName: string
     ownerUserId: string
     originWorkspaceId: string
+    sourceFileId?: string         // source object key — lets save-time dedup query the meta partition
     scope: MediaLibraryScope
     scopeOwnerId: string
     scopeAndOwner: string
@@ -1627,16 +1630,13 @@ export type WorkspaceAccessList = {
 }
 
 export type Document = {
-    documentId: string
-    workspaceId: string
-    revision: number
+    documentId: string        // SK — immutable id within the workspace partition
+    workspaceId: string       // PK — the scope the document is listed by
     title: string
     content: string
-    prevRevision: number
     proseMirrorVersion?: number
     createdAt: number
     updatedAt: number
-    revisionExpiresAt?: number
 }
 
 export type DocumentMeta = {

--- a/packages/lixpi/dynamodb-service/src/dynamodb-service.test.ts
+++ b/packages/lixpi/dynamodb-service/src/dynamodb-service.test.ts
@@ -2,7 +2,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import DynamoDBService from './dynamodb-service.ts'
+import DynamoDBService, { isTransactionConditionalCheckFailure } from './dynamodb-service.ts'
 
 type SendMock = ReturnType<typeof vi.fn>
 
@@ -695,25 +695,58 @@ describe('DynamoDBService', () => {
     })
 
     // =============================================================================
-    // transactWriteItems
+    // transactWrite
     // =============================================================================
 
-    describe('transactWriteItems', () => {
-        it('returns undefined when no transaction items are provided', async () => {
+    describe('transactWrite', () => {
+        it('throws when no operations are provided', async () => {
             const service = new DynamoDBService({ region: 'us-east-1' })
             const sendMock = vi.fn()
             setDocumentClientSend(service, sendMock)
 
-            const result = await service.transactWriteItems({ transactItems: [], origin: 'trans' })
-
-            expect(result).toBeUndefined()
+            await expect(
+                service.transactWrite({ operations: [], origin: 'trans' })
+            ).rejects.toThrow('at least one operation must be provided')
             expect(sendMock).not.toHaveBeenCalled()
-            expect(consoleErrorSpy).toHaveBeenCalledWith(
-                'Error: At least one transaction item must be provided!, origin: trans'
+        })
+
+        it('builds Put, Update, and Delete transact items from typed operations', async () => {
+            const service = new DynamoDBService({ region: 'us-east-1' })
+            const sendMock = vi.fn().mockResolvedValue({
+                ResponseMetadata: {},
+                ConsumedCapacity: [{ CapacityUnits: 6 }],
+            })
+            setDocumentClientSend(service, sendMock)
+
+            await service.transactWrite({
+                operations: [
+                    { type: 'put', tableName: 'users', item: { id: 'u1' } },
+                    { type: 'update', tableName: 'users-meta', key: { id: 'u1' }, updates: { status: 'ready' } },
+                    { type: 'delete', tableName: 'users-access', key: { id: 'u1' } },
+                ],
+                origin: 'trans2',
+            })
+
+            const input = (sendMock.mock.calls[0][0] as { input: Record<string, any> }).input
+            expect(input.TransactItems).toEqual([
+                { Put: { TableName: 'users', Item: { id: 'u1' } } },
+                {
+                    Update: {
+                        TableName: 'users-meta',
+                        Key: { id: 'u1' },
+                        UpdateExpression: 'SET #status = :status',
+                        ExpressionAttributeNames: { '#status': 'status' },
+                        ExpressionAttributeValues: { ':status': 'ready' },
+                    },
+                },
+                { Delete: { TableName: 'users-access', Key: { id: 'u1' } } },
+            ])
+            expect(consoleInfoSpy).toHaveBeenCalledWith(
+                expect.stringContaining('DynamoDB -> transactWrite users,users-meta,users-access, capacityUnits: 6,')
             )
         })
 
-        it('returns response and writes consumed capacity info', async () => {
+        it('passes custom update expressions and conditions through', async () => {
             const service = new DynamoDBService({ region: 'us-east-1' })
             const sendMock = vi.fn().mockResolvedValue({
                 ResponseMetadata: {},
@@ -721,32 +754,60 @@ describe('DynamoDBService', () => {
             })
             setDocumentClientSend(service, sendMock)
 
-            const result = await service.transactWriteItems({
-                transactItems: [{ Put: { TableName: 'users', Item: { id: 'u1' } } }],
-                origin: 'trans2',
+            await service.transactWrite({
+                operations: [
+                    {
+                        type: 'update',
+                        tableName: 'workspaces',
+                        key: { workspaceId: 'ws-1' },
+                        updateExpression: 'SET #updatedAt = :updatedAt',
+                        conditionExpression: '#updatedAt = :expected',
+                        expressionAttributeNames: { '#updatedAt': 'updatedAt' },
+                        expressionAttributeValues: { ':updatedAt': 2, ':expected': 1 },
+                    },
+                ],
+                origin: 'trans3',
             })
 
-            expect(result).toEqual({
-                ResponseMetadata: {},
-                ConsumedCapacity: [{ CapacityUnits: 2 }],
+            const input = (sendMock.mock.calls[0][0] as { input: Record<string, any> }).input
+            expect(input.TransactItems[0].Update).toMatchObject({
+                UpdateExpression: 'SET #updatedAt = :updatedAt',
+                ConditionExpression: '#updatedAt = :expected',
             })
-            expect(consoleInfoSpy).toHaveBeenCalledWith(
-                expect.stringContaining('DynamoDB -> transactWriteItems users, capacityUnits: 2,')
-            )
         })
 
-        it('rethrows and logs when write fails', async () => {
+        it('rethrows and logs when the transaction fails', async () => {
             const service = new DynamoDBService({ region: 'us-east-1' })
             const error = new Error('transact fail')
             const sendMock = vi.fn().mockRejectedValue(error)
             setDocumentClientSend(service, sendMock)
 
             await expect(
-                service.transactWriteItems({
-                    transactItems: [{ Put: { TableName: 'users', Item: { id: 'u1' } } }],
+                service.transactWrite({
+                    operations: [{ type: 'put', tableName: 'users', item: { id: 'u1' } }],
                 })
             ).rejects.toThrow('transact fail')
             expect(consoleErrorSpy).toHaveBeenCalledWith('Error completing DynamoDB transaction:', error)
+        })
+
+        it('suppresses logging for conditional-check cancellations when asked', async () => {
+            const service = new DynamoDBService({ region: 'us-east-1' })
+            const error = Object.assign(new Error('cancelled'), {
+                name: 'TransactionCanceledException',
+                CancellationReasons: [{ Code: 'ConditionalCheckFailed' }, { Code: 'None' }],
+            })
+            const sendMock = vi.fn().mockRejectedValue(error)
+            setDocumentClientSend(service, sendMock)
+
+            await expect(
+                service.transactWrite({
+                    operations: [{ type: 'put', tableName: 'users', item: { id: 'u1' } }],
+                    logConditionalCheckFailures: false,
+                })
+            ).rejects.toThrow('cancelled')
+            expect(consoleErrorSpy).not.toHaveBeenCalledWith('Error completing DynamoDB transaction:', error)
+            expect(isTransactionConditionalCheckFailure(error)).toBe(true)
+            expect(isTransactionConditionalCheckFailure(new Error('other'))).toBe(false)
         })
     })
 

--- a/packages/lixpi/dynamodb-service/src/dynamodb-service.ts
+++ b/packages/lixpi/dynamodb-service/src/dynamodb-service.ts
@@ -25,6 +25,33 @@ const toCapacityUnits = (cc) => {
     return cc?.CapacityUnits ?? 0
 }
 
+// One operation inside a transaction — same shapes the models pass to
+// putItem / updateItem / deleteItems, discriminated by `type`. Soft deletes
+// are expressed as a 'update' setting the TTL attribute.
+export type TransactOperation =
+    | { type: 'put'; tableName: string; item: Record<string, unknown> }
+    | {
+        type: 'update'
+        tableName: string
+        key: Record<string, unknown>
+        updates?: Record<string, unknown>
+        updateExpression?: string
+        expressionAttributeNames?: Record<string, string>
+        expressionAttributeValues?: Record<string, unknown>
+        conditionExpression?: string
+    }
+    | { type: 'delete'; tableName: string; key: Record<string, unknown> }
+
+// A transaction is cancelled as a whole; a failed per-item condition surfaces
+// as TransactionCanceledException with a ConditionalCheckFailed reason instead
+// of ConditionalCheckFailedException. Models use this to keep their existing
+// optimistic-concurrency retry paths.
+export const isTransactionConditionalCheckFailure = (error: unknown): boolean => {
+    const candidate = error as { name?: string; CancellationReasons?: Array<{ Code?: string }> }
+    return candidate?.name === 'TransactionCanceledException'
+        && (candidate.CancellationReasons ?? []).some((reason) => reason?.Code === 'ConditionalCheckFailed')
+}
+
 const logStats = ({ operation, operationType, capacityUnits, tableName, origin }) => {
     let logColor = ''
 
@@ -459,14 +486,60 @@ export default class DynamoDBService {
         }
     }
 
-    async transactWriteItems({
-        transactItems = [],
+    // One atomic multi-table write. Operations mirror the argument shapes of
+    // putItem / updateItem / deleteItems; the raw SDK TransactItems are built
+    // internally so models never touch SDK shapes. Throws on cancellation —
+    // when it throws, nothing was applied.
+    async transactWrite({
+        operations,
+        logConditionalCheckFailures = true,
         origin = 'unknown'
+    }: {
+        operations: TransactOperation[]
+        logConditionalCheckFailures?: boolean
+        origin?: string
     }) {
-        if (transactItems.length === 0) {
-            console.error(`Error: At least one transaction item must be provided!, origin: ${origin}`)
-            return
+        if (!operations || operations.length === 0) {
+            throw new Error(`DynamoDB transactWrite: at least one operation must be provided, origin: ${origin}`)
         }
+
+        const transactItems = operations.map((operation) => {
+            if (operation.type === 'put') {
+                return { Put: { TableName: operation.tableName, Item: operation.item } }
+            }
+
+            if (operation.type === 'delete') {
+                return { Delete: { TableName: operation.tableName, Key: operation.key } }
+            }
+
+            // 'update' — same expression building rules as updateItem: simple
+            // `updates` map preferred, custom expression as the escape hatch.
+            let updateExpression = operation.updateExpression ?? ''
+            let expressionAttributeNames = operation.expressionAttributeNames ?? {}
+            let expressionAttributeValues = operation.expressionAttributeValues ?? {}
+
+            if (operation.updates && Object.keys(operation.updates).length > 0) {
+                const prepared = this.prepareAttributes(operation.updates)
+                updateExpression = `SET ${prepared.expression}`
+                expressionAttributeNames = { ...prepared.expressionAttributeNames, ...expressionAttributeNames }
+                expressionAttributeValues = { ...prepared.expressionAttributeValues, ...expressionAttributeValues }
+            }
+
+            if (!updateExpression) {
+                throw new Error(`DynamoDB transactWrite: update operation for ${operation.tableName} needs 'updates' or 'updateExpression', origin: ${origin}`)
+            }
+
+            return {
+                Update: {
+                    TableName: operation.tableName,
+                    Key: operation.key,
+                    UpdateExpression: updateExpression,
+                    ...(Object.keys(expressionAttributeNames).length > 0 && { ExpressionAttributeNames: expressionAttributeNames }),
+                    ...(Object.keys(expressionAttributeValues).length > 0 && { ExpressionAttributeValues: expressionAttributeValues }),
+                    ...(operation.conditionExpression && { ConditionExpression: operation.conditionExpression })
+                }
+            }
+        })
 
         try {
             const response = await this.dynamodbDocumentClient.send(new TransactWriteCommand({
@@ -475,16 +548,18 @@ export default class DynamoDBService {
             }))
 
             logStats({
-                operation: 'transactWriteItems',
+                operation: 'transactWrite',
                 operationType: 'write',
                 capacityUnits: toCapacityUnits(response.ConsumedCapacity),
-                tableName: transactItems.map((item) => Object.values(item)[0]?.TableName).join(','),
+                tableName: operations.map((operation) => operation.tableName).join(','),
                 origin
             })
 
             return response
         } catch (error) {
-            console.error('Error completing DynamoDB transaction:', error)
+            if (logConditionalCheckFailures || !isTransactionConditionalCheckFailure(error)) {
+                console.error('Error completing DynamoDB transaction:', error)
+            }
             throw error
         }
     }

--- a/services/api/src/NATS/subscriptions/document-subjects.test.ts
+++ b/services/api/src/NATS/subscriptions/document-subjects.test.ts
@@ -111,15 +111,14 @@ describe('Document subject handlers — ownership and persistence', () => {
     })
 
     it('returns a persisted document for GET_DOCUMENT', async () => {
-        const persisted = { documentId: 'document-1', revision: 1, workspaceId: 'workspace-1' }
+        const persisted = { documentId: 'document-1', workspaceId: 'workspace-1' }
         mocks.document.getDocument.mockResolvedValueOnce(persisted)
 
         const result = await getHandler(SUBJECTS.GET_DOCUMENT)(baseDocumentData)
 
         expect(mocks.document.getDocument).toHaveBeenCalledWith({
             workspaceId: 'workspace-1',
-            documentId: 'document-1',
-            revision: 1,
+            documentId: 'document-1'
         })
         expect(result).toEqual(persisted)
     })
@@ -131,7 +130,7 @@ describe('Document subject handlers — ownership and persistence', () => {
             content: { type: 'doc' },
         }
 
-        const created = { documentId: 'new-document', revision: 1 }
+        const created = { documentId: 'new-document' }
         mocks.document.createDocument.mockResolvedValueOnce(created)
 
         const result = await getHandler(SUBJECTS.CREATE_DOCUMENT)(payload)
@@ -148,7 +147,6 @@ describe('Document subject handlers — ownership and persistence', () => {
         const payload = {
             ...baseDocumentData,
             title: 'Updated',
-            prevRevision: 0,
             content: { type: 'doc' },
         }
 
@@ -158,7 +156,6 @@ describe('Document subject handlers — ownership and persistence', () => {
             workspaceId: 'workspace-1',
             documentId: 'document-1',
             title: 'Updated',
-            prevRevision: 0,
             content: { type: 'doc' },
         })
         expect(result).toEqual({ success: true, documentId: 'document-1' })
@@ -430,7 +427,6 @@ describe('Document resume reconciliation', () => {
         expect(mocks.document.getDocument).toHaveBeenCalledWith({
             workspaceId: 'workspace-1',
             documentId: 'document-1',
-            revision: 1,
         })
         expect(result.events).toEqual([
             { kind: 'START', baseVersion: 1, version: 2, streamSequence: 2 },

--- a/services/api/src/NATS/subscriptions/document-subjects.ts
+++ b/services/api/src/NATS/subscriptions/document-subjects.ts
@@ -71,7 +71,6 @@ async function loadProseMirrorSnapshot(coordinate: DocCoordinate): Promise<DocSn
     const document = await Document.getDocument({
         workspaceId: coordinate.workspaceId,
         documentId: coordinate.docId,
-        revision: 1,
     })
     if (!document || 'error' in document) return null
     const doc = parseStoredDocContent(document.content)
@@ -228,8 +227,7 @@ export const documentSubjects = [
 
             return await Document.getDocument({
                 workspaceId,
-                documentId,
-                revision: 1
+                documentId
             })
         }
     },
@@ -286,7 +284,6 @@ export const documentSubjects = [
                 workspaceId,
                 documentId,
                 title: data.title,
-                prevRevision: data.prevRevision,
                 content: data.content
             })
 

--- a/services/api/src/llm/graph/workspace-context-resolver.test.ts
+++ b/services/api/src/llm/graph/workspace-context-resolver.test.ts
@@ -224,13 +224,11 @@ function createDeps(parsedInput: { selections: Array<Record<string, unknown>> } 
     const getDocument = vi.fn(async () => ({
         documentId: 'doc-cubist',
         workspaceId: 'workspace-1',
-        revision: 1,
         title: 'Cubist Dog',
         content: JSON.stringify({
             type: 'doc',
             content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Full cubist dog document text.' }] }],
         }),
-        prevRevision: 1,
         createdAt: 1,
         updatedAt: 1,
     }))
@@ -454,7 +452,7 @@ describe('resolveWorkspaceContext', () => {
         ])
         expect(update.workspaceContextResolution?.narrowedMediaNodeIds).toEqual(['team-video', 'goat-image'])
         expect(publisher.contextRelevanceResolved).toHaveBeenCalledOnce()
-        expect(getDocument).toHaveBeenCalledWith(expect.objectContaining({ documentId: 'doc-cubist', workspaceId: 'workspace-1', revision: 1 }))
+        expect(getDocument).toHaveBeenCalledWith(expect.objectContaining({ documentId: 'doc-cubist', workspaceId: 'workspace-1' }))
         expect(getAiChatThread).toHaveBeenCalledWith(expect.objectContaining({ threadId: 'thread-notes', workspaceId: 'workspace-1' }))
 
         const textBlocks = getInputTextBlocks(update)

--- a/services/api/src/llm/graph/workspace-context-resolver.ts
+++ b/services/api/src/llm/graph/workspace-context-resolver.ts
@@ -365,7 +365,6 @@ const resolveDocumentText = async (
     const document = await (deps.getDocument ?? DocumentModel.getDocument)({
         workspaceId: state.workspaceId,
         documentId: referenceId,
-        revision: 1,
     } as any)
     if (hasModelError(document)) {
         const text = getFallbackText(node)

--- a/services/api/src/models/document.test.ts
+++ b/services/api/src/models/document.test.ts
@@ -11,6 +11,7 @@ const dynamo = {
     putItem: vi.fn(),
     updateItem: vi.fn(),
     queryItems: vi.fn(),
+    transactWrite: vi.fn(),
 }
 
 beforeEach(() => {
@@ -25,12 +26,12 @@ afterEach(() => {
 })
 
 // =============================================================================
-// DOCUMENT MODEL — PROSEMIRROR VERSION
+// DOCUMENT MODEL — WORKSPACE-PARTITIONED KEY + TRANSACTIONAL WRITES
 // =============================================================================
 
 describe('Document.update', () => {
-    it('persists proseMirrorVersion on the latest document record when provided', async () => {
-        dynamo.updateItem.mockResolvedValue(undefined)
+    it('persists proseMirrorVersion on the document record when provided', async () => {
+        dynamo.transactWrite.mockResolvedValue(undefined)
 
         await Document.update({
             workspaceId: 'workspace-1',
@@ -40,25 +41,28 @@ describe('Document.update', () => {
             proseMirrorVersion: 9,
         })
 
-        expect(dynamo.updateItem).toHaveBeenNthCalledWith(1, expect.objectContaining({
-            key: { documentId: 'document-1', revision: 1 },
+        expect(dynamo.transactWrite).toHaveBeenCalledTimes(1)
+        const { operations, origin } = dynamo.transactWrite.mock.calls[0][0]
+        expect(origin).toBe('updateDocument')
+        expect(operations[0]).toMatchObject({
+            type: 'update',
+            key: { workspaceId: 'workspace-1', documentId: 'document-1' },
             updates: expect.objectContaining({
                 title: 'Updated title',
                 content: { type: 'doc', content: [] },
                 proseMirrorVersion: 9,
                 updatedAt: expect.any(Number),
             }),
-            origin: 'updateDocument',
-        }))
-        expect(dynamo.updateItem).toHaveBeenNthCalledWith(2, expect.objectContaining({
+        })
+        expect(operations[1]).toMatchObject({
+            type: 'update',
             key: { documentId: 'document-1' },
-            origin: 'updateDocument',
-        }))
-        expect(Object.hasOwn(dynamo.updateItem.mock.calls[1]?.[0].updates, 'proseMirrorVersion')).toBe(false)
+        })
+        expect(Object.hasOwn(operations[1].updates, 'proseMirrorVersion')).toBe(false)
     })
 
     it('does not write proseMirrorVersion when it is omitted', async () => {
-        dynamo.updateItem.mockResolvedValue(undefined)
+        dynamo.transactWrite.mockResolvedValue(undefined)
 
         await Document.update({
             workspaceId: 'workspace-1',
@@ -67,11 +71,12 @@ describe('Document.update', () => {
             content: { type: 'doc', content: [] } as any,
         })
 
-        expect(Object.hasOwn(dynamo.updateItem.mock.calls[0]?.[0].updates, 'proseMirrorVersion')).toBe(false)
+        const { operations } = dynamo.transactWrite.mock.calls[0][0]
+        expect(Object.hasOwn(operations[0].updates, 'proseMirrorVersion')).toBe(false)
     })
 
     it('omits undefined document fields from partial updates', async () => {
-        dynamo.updateItem.mockResolvedValue(undefined)
+        dynamo.transactWrite.mockResolvedValue(undefined)
 
         await Document.update({
             workspaceId: 'workspace-1',
@@ -79,22 +84,19 @@ describe('Document.update', () => {
             title: 'Updated title',
         })
 
-        expect(dynamo.updateItem).toHaveBeenNthCalledWith(1, expect.objectContaining({
-            updates: expect.objectContaining({
-                title: 'Updated title',
-                updatedAt: expect.any(Number),
-            }),
-        }))
-        expect(Object.hasOwn(dynamo.updateItem.mock.calls[0]?.[0].updates, 'content')).toBe(false)
-        expect(dynamo.updateItem).toHaveBeenNthCalledWith(2, expect.objectContaining({
-            updates: expect.objectContaining({
-                title: 'Updated title',
-                updatedAt: expect.any(Number),
-            }),
-        }))
+        let { operations } = dynamo.transactWrite.mock.calls[0][0]
+        expect(operations[0].updates).toMatchObject({
+            title: 'Updated title',
+            updatedAt: expect.any(Number),
+        })
+        expect(Object.hasOwn(operations[0].updates, 'content')).toBe(false)
+        expect(operations[1].updates).toMatchObject({
+            title: 'Updated title',
+            updatedAt: expect.any(Number),
+        })
 
         vi.clearAllMocks()
-        dynamo.updateItem.mockResolvedValue(undefined)
+        dynamo.transactWrite.mockResolvedValue(undefined)
 
         await Document.update({
             workspaceId: 'workspace-1',
@@ -102,13 +104,125 @@ describe('Document.update', () => {
             content: { type: 'doc', content: [] } as any,
         })
 
-        expect(dynamo.updateItem).toHaveBeenNthCalledWith(1, expect.objectContaining({
-            updates: expect.objectContaining({
-                content: { type: 'doc', content: [] },
-                updatedAt: expect.any(Number),
-            }),
+        ;({ operations } = dynamo.transactWrite.mock.calls[0][0])
+        expect(operations[0].updates).toMatchObject({
+            content: { type: 'doc', content: [] },
+            updatedAt: expect.any(Number),
+        })
+        expect(Object.hasOwn(operations[0].updates, 'title')).toBe(false)
+        expect(Object.hasOwn(operations[1].updates, 'title')).toBe(false)
+    })
+})
+
+describe('Document.getDocument', () => {
+    it('point-reads the document by workspace partition and document id', async () => {
+        dynamo.getItem.mockResolvedValue({ documentId: 'document-1', workspaceId: 'workspace-1' })
+
+        const document = await Document.getDocument({ workspaceId: 'workspace-1', documentId: 'document-1' })
+
+        expect(dynamo.getItem).toHaveBeenCalledWith(expect.objectContaining({
+            key: { workspaceId: 'workspace-1', documentId: 'document-1' },
         }))
-        expect(Object.hasOwn(dynamo.updateItem.mock.calls[0]?.[0].updates, 'title')).toBe(false)
-        expect(Object.hasOwn(dynamo.updateItem.mock.calls[1]?.[0].updates, 'title')).toBe(false)
+        expect(document).toEqual({ documentId: 'document-1', workspaceId: 'workspace-1' })
+    })
+
+    it('normalizes missing documents into NOT_FOUND', async () => {
+        dynamo.getItem.mockResolvedValue(undefined)
+
+        await expect(Document.getDocument({ workspaceId: 'workspace-1', documentId: 'missing' }))
+            .resolves.toEqual({ error: 'NOT_FOUND' })
+    })
+})
+
+describe('Document.getWorkspaceDocuments', () => {
+    it('queries the workspace partition and returns documents newest-first', async () => {
+        dynamo.queryItems.mockResolvedValue({
+            items: [
+                { documentId: 'doc-a', updatedAt: 10 },
+                { documentId: 'doc-b', updatedAt: 40 },
+                { documentId: 'doc-c', updatedAt: 30 },
+            ],
+        })
+
+        const documents = await Document.getWorkspaceDocuments({ workspaceId: 'workspace-1' })
+
+        expect(dynamo.queryItems).toHaveBeenCalledWith(expect.objectContaining({
+            keyConditions: { workspaceId: 'workspace-1' },
+            fetchAllItems: true,
+        }))
+        expect(dynamo.queryItems.mock.calls[0][0]).not.toHaveProperty('indexName')
+        expect(documents.map((doc: any) => doc.documentId)).toEqual(['doc-b', 'doc-c', 'doc-a'])
+    })
+})
+
+describe('Document.createDocument', () => {
+    it('writes Main and Meta rows in a single transaction keyed by the workspace partition', async () => {
+        dynamo.transactWrite.mockResolvedValue(undefined)
+
+        const created = await Document.createDocument({
+            workspaceId: 'workspace-1',
+            title: 'Q3 Plan',
+            content: { type: 'doc', content: [] } as any,
+        })
+
+        expect(dynamo.transactWrite).toHaveBeenCalledTimes(1)
+        const { operations } = dynamo.transactWrite.mock.calls[0][0]
+        expect(operations).toHaveLength(2)
+        expect(operations[0].type).toBe('put')
+        expect(operations[0].item.workspaceId).toBe('workspace-1')
+        expect(operations[0].item.documentId).toBe(created!.documentId)
+        expect(operations[1].type).toBe('put')
+        expect(operations[1].item.documentId).toBe(created!.documentId)
+    })
+
+    it('returns undefined when the transaction fails, leaving neither a Main nor a Meta row', async () => {
+        dynamo.transactWrite.mockRejectedValue(new Error('cancelled'))
+
+        const created = await Document.createDocument({
+            workspaceId: 'workspace-1',
+            title: 'Q3 Plan',
+            content: { type: 'doc', content: [] } as any,
+        })
+
+        expect(created).toBeUndefined()
+    })
+})
+
+describe('Document.delete', () => {
+    it('deletes the Main row and the Meta row in one transaction', async () => {
+        dynamo.transactWrite.mockResolvedValue(undefined)
+
+        await Document.delete({ documentId: 'document-1', workspaceId: 'workspace-1' })
+
+        const { operations } = dynamo.transactWrite.mock.calls[0][0]
+        expect(operations[0]).toMatchObject({
+            type: 'delete',
+            key: { workspaceId: 'workspace-1', documentId: 'document-1' },
+        })
+        expect(operations[1]).toMatchObject({
+            type: 'delete',
+            key: { documentId: 'document-1' },
+        })
+    })
+})
+
+describe('Document.deleteWorkspaceDocuments', () => {
+    it('deletes each document row and its meta row transactionally', async () => {
+        dynamo.queryItems.mockResolvedValue({
+            items: [
+                { documentId: 'doc-a' },
+                { documentId: 'doc-b' },
+            ],
+        })
+        dynamo.transactWrite.mockResolvedValue(undefined)
+
+        const deleted = await Document.deleteWorkspaceDocuments({ workspaceId: 'workspace-1' })
+
+        expect(deleted).toBe(2)
+        expect(dynamo.transactWrite).toHaveBeenCalledTimes(2)
+        expect(dynamo.transactWrite.mock.calls[0][0].operations).toEqual([
+            expect.objectContaining({ type: 'delete', key: { workspaceId: 'workspace-1', documentId: 'doc-a' } }),
+            expect.objectContaining({ type: 'delete', key: { documentId: 'doc-a' } }),
+        ])
     })
 })

--- a/services/api/src/models/document.ts
+++ b/services/api/src/models/document.ts
@@ -3,7 +3,7 @@
 import * as process from 'process'
 import { v4 as uuid } from 'uuid'
 
-import { getDynamoDbTableStageName, type Document, type DocumentMeta, type DocumentFile } from '@lixpi/constants'
+import { getDynamoDbTableStageName, type Document, type DocumentMeta } from '@lixpi/constants'
 import type { Partial, Pick } from 'type-fest'
 
 const {
@@ -11,27 +11,21 @@ const {
 	STAGE
 } = process.env
 
-import { sliceTime } from '../helpers/time-operations.ts'
 import User from './user.ts'
 
 export default {
 	getDocument: async ({
 		documentId,
-		revision,
 		workspaceId
-	}: Pick<Document, 'documentId' | 'revision' | 'workspaceId'>): Promise<Document | { error: string }> => {
+	}: Pick<Document, 'documentId' | 'workspaceId'>): Promise<Document | { error: string }> => {
 		const document = await dynamoDBService.getItem({
 			tableName: getDynamoDbTableStageName('DOCUMENTS', ORG_NAME, STAGE),
-			key: { documentId, revision },
-			origin: `model::Document->get(${documentId}:${revision})`
+			key: { workspaceId, documentId },
+			origin: `model::Document->get(${documentId})`
 		})
 
 		if (!document || Object.keys(document).length === 0) {
 			return { error: 'NOT_FOUND' }
-		}
-
-		if (document.workspaceId !== workspaceId) {
-			return { error: 'DOCUMENT_NOT_IN_WORKSPACE' }
 		}
 
 		return document
@@ -42,16 +36,14 @@ export default {
 	}: { workspaceId: string }): Promise<Document[]> => {
 		const documents = await dynamoDBService.queryItems({
 			tableName: getDynamoDbTableStageName('DOCUMENTS', ORG_NAME, STAGE),
-			indexName: 'workspaceId',
 			keyConditions: { workspaceId },
 			fetchAllItems: true,
-			scanIndexForward: false,
 			origin: 'model::Document->getWorkspaceDocuments()'
 		})
 
-		// Filter to only get the latest revision (revision = 1) in memory
-		const latestRevisions = (documents?.items || []).filter((doc: Document) => doc.revision === 1)
-		return latestRevisions
+		// Newest-first in memory over the workspace partition
+		return (documents?.items || [])
+			.sort((left: Document, right: Document) => right.updatedAt - left.updatedAt)
 	},
 
 	createDocument: async ({
@@ -60,36 +52,37 @@ export default {
 		content
 	}: Pick<Document, 'workspaceId' | 'title' | 'content'>): Promise<Document | undefined> => {
 		const currentDate = new Date().getTime()
-		const revision = 1
 
 		const newDocumentData: Document = {
 			documentId: uuid(),
 			workspaceId,
-			revision,
 			title,
 			content,
-			prevRevision: 1,
 			createdAt: currentDate,
 			updatedAt: currentDate
 		}
 
 		try {
-			await dynamoDBService.putItem({
-				tableName: getDynamoDbTableStageName('DOCUMENTS', ORG_NAME, STAGE),
-				item: newDocumentData,
-				origin: 'createDocument'
-			})
-
-			await dynamoDBService.putItem({
-				tableName: getDynamoDbTableStageName('DOCUMENTS_META', ORG_NAME, STAGE),
-				item: {
-					documentId: newDocumentData.documentId,
-					workspaceId: newDocumentData.workspaceId,
-					title: newDocumentData.title,
-					tags: [],
-					createdAt: newDocumentData.createdAt,
-					updatedAt: newDocumentData.updatedAt
-				},
+			await dynamoDBService.transactWrite({
+				operations: [
+					{
+						type: 'put',
+						tableName: getDynamoDbTableStageName('DOCUMENTS', ORG_NAME, STAGE),
+						item: newDocumentData
+					},
+					{
+						type: 'put',
+						tableName: getDynamoDbTableStageName('DOCUMENTS_META', ORG_NAME, STAGE),
+						item: {
+							documentId: newDocumentData.documentId,
+							workspaceId: newDocumentData.workspaceId,
+							title: newDocumentData.title,
+							tags: [],
+							createdAt: newDocumentData.createdAt,
+							updatedAt: newDocumentData.updatedAt
+						}
+					}
+				],
 				origin: 'createDocument'
 			})
 
@@ -103,61 +96,41 @@ export default {
 		title,
 		content,
 		documentId,
-		prevRevision,
 		workspaceId,
 		proseMirrorVersion
 	}: Partial<Document> & { documentId: string; workspaceId: string }): Promise<void> => {
 		const currentDate = new Date().getTime()
-		const currentRevision = sliceTime({ precision: 'hours' })
 
 		// TODO: Check if user has permission to update document
 
 		try {
-			// Create a new revision save point if the current revision is greater than the previous revision
-			// if(prevRevision < currentRevision) {
-			// 	await dynamoDBService.putItem({
-			// 		tableName: DYNAMODB_TABLES.DOCUMENTS,
-			// 		partitionKeyName: 'documentId',
-			// 		partitionKeyValue: documentId,
-			// 		sortKeyName: 'revision',
-			// 		sortKeyValue: currentRevision,
-			// 		item: {
-			// 			title,
-			// 			aiModel,
-			// 			content,
-			// 			prevRevision,
-			// 			revisionExpiresAt: sliceTime({ precision: 'hours', modify: { operation: 'add', amount: 1, unit: 'hours' } }),
-			// 			createdAt: currentDate,
-			// 			updatedAt: currentDate,
-			// 		},
-			// 		origin: 'updateDocument::revisionSavePoint'
-			// 	})
-			// }
-
 			const documentUpdates: Record<string, unknown> = {
-				// prevRevision: currentRevision,    // TODO: turn back on when versioning is ready
 				updatedAt: currentDate
 			}
 			if (title !== undefined) documentUpdates.title = title
 			if (content !== undefined) documentUpdates.content = content
 			if (proseMirrorVersion !== undefined) documentUpdates.proseMirrorVersion = proseMirrorVersion
 
-			await dynamoDBService.updateItem({
-				tableName: getDynamoDbTableStageName('DOCUMENTS', ORG_NAME, STAGE),
-				key: { documentId, revision: 1 },
-				updates: documentUpdates,
-				origin: 'updateDocument'
-			})
-
 			const documentMetaUpdates: Record<string, unknown> = {
 				updatedAt: currentDate
 			}
 			if (title !== undefined) documentMetaUpdates.title = title
 
-			await dynamoDBService.updateItem({
-				tableName: getDynamoDbTableStageName('DOCUMENTS_META', ORG_NAME, STAGE),
-				key: { documentId },
-				updates: documentMetaUpdates,
+			await dynamoDBService.transactWrite({
+				operations: [
+					{
+						type: 'update',
+						tableName: getDynamoDbTableStageName('DOCUMENTS', ORG_NAME, STAGE),
+						key: { workspaceId, documentId },
+						updates: documentUpdates
+					},
+					{
+						type: 'update',
+						tableName: getDynamoDbTableStageName('DOCUMENTS_META', ORG_NAME, STAGE),
+						key: { documentId },
+						updates: documentMetaUpdates
+					}
+				],
 				origin: 'updateDocument'
 			})
 		}
@@ -251,81 +224,25 @@ export default {
 		workspaceId
 	}: Pick<Document, 'documentId' | 'workspaceId'>): Promise<{ status: string; documentId: string }> => {
 		try {
-			await dynamoDBService.softDeleteItem({
-				tableName: getDynamoDbTableStageName('DOCUMENTS', ORG_NAME, STAGE),
-				key: { documentId, revision: 1 },
-				timeToLiveAttributeName: 'revisionExpiresAt',
-				timeToLiveAttributeValue: sliceTime({ precision: 'hours', modify: { operation: 'add', amount: 1, unit: 'hours' } }),
-				origin: 'deleteDocument:Documents'
-			})
-
-			await dynamoDBService.deleteItems({
-				tableName: getDynamoDbTableStageName('DOCUMENTS_META', ORG_NAME, STAGE),
-				key: { documentId },
-				origin: 'deleteDocument:Meta'
+			await dynamoDBService.transactWrite({
+				operations: [
+					{
+						type: 'delete',
+						tableName: getDynamoDbTableStageName('DOCUMENTS', ORG_NAME, STAGE),
+						key: { workspaceId, documentId }
+					},
+					{
+						type: 'delete',
+						tableName: getDynamoDbTableStageName('DOCUMENTS_META', ORG_NAME, STAGE),
+						key: { documentId }
+					}
+				],
+				origin: 'deleteDocument'
 			})
 
 			return { status: 'deleted', documentId }
 		} catch (error) {
 			throw error
-		}
-	},
-
-	addFile: async ({
-		documentId,
-		file
-	}: { documentId: string; file: DocumentFile }): Promise<void> => {
-		try {
-			// Get current document to append to files array
-			const document = await dynamoDBService.getItem({
-				tableName: getDynamoDbTableStageName('DOCUMENTS', ORG_NAME, STAGE),
-				key: { documentId, revision: 1 },
-				origin: 'addFile:getDocument'
-			})
-
-			const currentFiles = document?.files || []
-			const updatedFiles = [...currentFiles, file]
-
-			await dynamoDBService.updateItem({
-				tableName: getDynamoDbTableStageName('DOCUMENTS', ORG_NAME, STAGE),
-				key: { documentId, revision: 1 },
-				updates: {
-					files: updatedFiles,
-					updatedAt: Date.now()
-				},
-				origin: 'addFile'
-			})
-		} catch (e) {
-			throw e
-		}
-	},
-
-	removeFile: async ({
-		documentId,
-		fileId
-	}: { documentId: string; fileId: string }): Promise<void> => {
-		try {
-			// Get current document to filter out the file
-			const document = await dynamoDBService.getItem({
-				tableName: getDynamoDbTableStageName('DOCUMENTS', ORG_NAME, STAGE),
-				key: { documentId, revision: 1 },
-				origin: 'removeFile:getDocument'
-			})
-
-			const currentFiles = document?.files || []
-			const updatedFiles = currentFiles.filter((f: DocumentFile) => f.id !== fileId)
-
-			await dynamoDBService.updateItem({
-				tableName: getDynamoDbTableStageName('DOCUMENTS', ORG_NAME, STAGE),
-				key: { documentId, revision: 1 },
-				updates: {
-					files: updatedFiles,
-					updatedAt: Date.now()
-				},
-				origin: 'removeFile'
-			})
-		} catch (e) {
-			throw e
 		}
 	},
 
@@ -340,31 +257,33 @@ export default {
 		const documentData: Document = {
 			documentId,
 			workspaceId,
-			revision: 1,
 			title,
 			content,
-			prevRevision: 1,
 			createdAt,
 			updatedAt
 		}
 
 		try {
-			await dynamoDBService.putItem({
-				tableName: getDynamoDbTableStageName('DOCUMENTS', ORG_NAME, STAGE),
-				item: documentData,
-				origin: 'importDocument'
-			})
-
-			await dynamoDBService.putItem({
-				tableName: getDynamoDbTableStageName('DOCUMENTS_META', ORG_NAME, STAGE),
-				item: {
-					documentId,
-					workspaceId,
-					title,
-					tags: [],
-					createdAt,
-					updatedAt
-				},
+			await dynamoDBService.transactWrite({
+				operations: [
+					{
+						type: 'put',
+						tableName: getDynamoDbTableStageName('DOCUMENTS', ORG_NAME, STAGE),
+						item: documentData
+					},
+					{
+						type: 'put',
+						tableName: getDynamoDbTableStageName('DOCUMENTS_META', ORG_NAME, STAGE),
+						item: {
+							documentId,
+							workspaceId,
+							title,
+							tags: [],
+							createdAt,
+							updatedAt
+						}
+					}
+				],
 				origin: 'importDocument'
 			})
 
@@ -379,7 +298,6 @@ export default {
 	}: { workspaceId: string }): Promise<number> => {
 		const documents = await dynamoDBService.queryItems({
 			tableName: getDynamoDbTableStageName('DOCUMENTS', ORG_NAME, STAGE),
-			indexName: 'workspaceId',
 			keyConditions: { workspaceId },
 			fetchAllItems: true,
 			origin: 'deleteWorkspaceDocuments:query'
@@ -388,21 +306,24 @@ export default {
 		const allDocuments = documents?.items || []
 		let deletedCount = 0
 
+		// One transaction per document: its row and its meta row commit or fail together
 		for (const doc of allDocuments) {
 			try {
-				await dynamoDBService.deleteItems({
-					tableName: getDynamoDbTableStageName('DOCUMENTS', ORG_NAME, STAGE),
-					key: { documentId: doc.documentId, revision: doc.revision },
-					origin: 'deleteWorkspaceDocuments:document'
+				await dynamoDBService.transactWrite({
+					operations: [
+						{
+							type: 'delete',
+							tableName: getDynamoDbTableStageName('DOCUMENTS', ORG_NAME, STAGE),
+							key: { workspaceId, documentId: doc.documentId }
+						},
+						{
+							type: 'delete',
+							tableName: getDynamoDbTableStageName('DOCUMENTS_META', ORG_NAME, STAGE),
+							key: { documentId: doc.documentId }
+						}
+					],
+					origin: 'deleteWorkspaceDocuments'
 				})
-
-				if (doc.revision === 1) {
-					await dynamoDBService.deleteItems({
-						tableName: getDynamoDbTableStageName('DOCUMENTS_META', ORG_NAME, STAGE),
-						key: { documentId: doc.documentId },
-						origin: 'deleteWorkspaceDocuments:meta'
-					})
-				}
 
 				deletedCount++
 			} catch (error) {

--- a/services/api/src/models/feature.ts
+++ b/services/api/src/models/feature.ts
@@ -66,21 +66,28 @@ const FeatureModel = {
         }
 
         try {
-            await dynamoDBService.putItem({
-                tableName: getDynamoDbTableStageName('FEATURES', ORG_NAME, STAGE),
-                item: feature, origin: 'Feature.createFeature',
-            })
-            await dynamoDBService.putItem({
-                tableName: getDynamoDbTableStageName('FEATURES_META', ORG_NAME, STAGE),
-                item: {
-                    featureId, category: data.category, name: data.name, summary: data.summary,
-                    tags: data.tags, scope, scopeOwnerId, status: 'active',
-                    ownerUserId: data.ownerUserId,
-                    sampleZeroKey: buildSampleKey(featureId, data.sampleImages[0]),
-                    sampleZeroUrl: getSampleUrl(data.sampleImages[0]),
-                    updatedAt: now,
-                } as FeatureMeta,
-                origin: 'Feature.createFeature:meta',
+            await dynamoDBService.transactWrite({
+                operations: [
+                    {
+                        type: 'put',
+                        tableName: getDynamoDbTableStageName('FEATURES', ORG_NAME, STAGE),
+                        item: feature,
+                    },
+                    {
+                        type: 'put',
+                        tableName: getDynamoDbTableStageName('FEATURES_META', ORG_NAME, STAGE),
+                        item: {
+                            featureId, category: data.category, name: data.name, summary: data.summary,
+                            tags: data.tags, scope, scopeOwnerId, status: 'active',
+                            ownerUserId: data.ownerUserId,
+                            scopeAndOwner: buildScopeAndOwnerKey(scope, scopeOwnerId),
+                            sampleZeroKey: buildSampleKey(featureId, data.sampleImages[0]),
+                            sampleZeroUrl: getSampleUrl(data.sampleImages[0]),
+                            updatedAt: now,
+                        } as FeatureMeta,
+                    },
+                ],
+                origin: 'Feature.createFeature',
             })
             return feature
         } catch (error) {
@@ -116,26 +123,28 @@ const FeatureModel = {
         scope: FeatureScope; scopeOwnerId: string; requesterContext: RequesterContext
         paging?: { limit?: number; lastKey?: Record<string, any> }
     }): Promise<{ items: FeatureMeta[]; lastKey?: Record<string, any> }> => {
-        const gsiKey = buildScopeAndOwnerKey(scope, scopeOwnerId)
+        // Meta partition query — the meta rows are projections, so this reads
+        // fewer bytes than the main-table GSI it replaces. Recency ordering is
+        // an in-memory sort over one org's features.
         const result = await dynamoDBService.queryItems({
-            tableName: getDynamoDbTableStageName('FEATURES', ORG_NAME, STAGE),
-            indexName: 'byScopeAndOwner', keyConditions: { scopeAndOwner: gsiKey },
-            fetchAllItems: !paging?.limit, limit: paging?.limit,
-            exclusiveStartKey: paging?.lastKey, scanIndexForward: false,
+            tableName: getDynamoDbTableStageName('FEATURES_META', ORG_NAME, STAGE),
+            keyConditions: { scopeAndOwner: buildScopeAndOwnerKey(scope, scopeOwnerId) },
+            fetchAllItems: true,
             origin: `Feature.listByScope(${scope})`,
         })
-        const items = (result?.items || []) as (Feature & { scopeAndOwner: string })[]
-        const visible = items.filter((f) => f.status === 'active' && canRead(requesterContext.userId, f, requesterContext.workspaceId, requesterContext.organizationId))
+        const items = (result?.items || []) as FeatureMeta[]
+        const visible = items
+            .filter((f) => f.status === 'active' && canRead(requesterContext.userId, f as unknown as Feature, requesterContext.workspaceId, requesterContext.organizationId))
+            .sort((left, right) => right.updatedAt - left.updatedAt)
         return {
             items: visible.map((f) => ({
                 featureId: f.featureId, category: f.category, name: f.name, summary: f.summary,
                 tags: f.tags, scope: f.scope, scopeOwnerId: f.scopeOwnerId, status: f.status,
                 ownerUserId: f.ownerUserId,
-                sampleZeroKey: buildSampleKey(f.featureId, f.sampleImages[0]),
-                sampleZeroUrl: getSampleUrl(f.sampleImages[0]),
+                sampleZeroKey: f.sampleZeroKey,
+                sampleZeroUrl: f.sampleZeroUrl,
                 updatedAt: f.updatedAt,
             })),
-            lastKey: result?.lastKey,
         }
     },
 
@@ -146,16 +155,53 @@ const FeatureModel = {
         const feature = await FeatureModel.getOwnedFeature({ featureId, ownerUserId })
         if ('error' in feature) return feature
         const now = Date.now()
-        await dynamoDBService.updateItem({ tableName: getDynamoDbTableStageName('FEATURES', ORG_NAME, STAGE), key: { featureId, version: 1 }, updates: { ...updates, updatedAt: now }, origin: 'Feature.updateFeature' })
         const metaUp: any = { updatedAt: now }
         if (updates.summary !== undefined) metaUp.summary = updates.summary
         if (updates.tags !== undefined) metaUp.tags = updates.tags
-        await dynamoDBService.updateItem({ tableName: getDynamoDbTableStageName('FEATURES_META', ORG_NAME, STAGE), key: { featureId }, updates: metaUp, origin: 'Feature.updateFeature:meta' })
+        await dynamoDBService.transactWrite({
+            operations: [
+                {
+                    type: 'update',
+                    tableName: getDynamoDbTableStageName('FEATURES', ORG_NAME, STAGE),
+                    key: { featureId, version: 1 },
+                    updates: { ...updates, updatedAt: now },
+                },
+                {
+                    type: 'update',
+                    tableName: getDynamoDbTableStageName('FEATURES_META', ORG_NAME, STAGE),
+                    key: { scopeAndOwner: buildScopeAndOwnerKey(feature.scope, feature.scopeOwnerId), featureId },
+                    updates: metaUp,
+                },
+            ],
+            origin: 'Feature.updateFeature',
+        })
     },
 
     deleteFeature: async ({ featureId }: { featureId: string }): Promise<void> => {
-        await dynamoDBService.deleteItems({ tableName: getDynamoDbTableStageName('FEATURES', ORG_NAME, STAGE), key: { featureId, version: 1 }, origin: 'Feature.deleteFeature' })
-        await dynamoDBService.deleteItems({ tableName: getDynamoDbTableStageName('FEATURES_META', ORG_NAME, STAGE), key: { featureId }, origin: 'Feature.deleteFeature:meta' })
+        // The meta row is addressed by scopeAndOwner — load the feature first
+        // to obtain it. Missing feature means there is nothing to delete.
+        const item = await dynamoDBService.getItem({
+            tableName: getDynamoDbTableStageName('FEATURES', ORG_NAME, STAGE),
+            key: { featureId, version: 1 },
+            origin: `Feature.deleteFeature(${featureId})`,
+        })
+        if (!item || Object.keys(item).length === 0) return
+        const feature = item as Feature
+        await dynamoDBService.transactWrite({
+            operations: [
+                {
+                    type: 'delete',
+                    tableName: getDynamoDbTableStageName('FEATURES', ORG_NAME, STAGE),
+                    key: { featureId, version: 1 },
+                },
+                {
+                    type: 'delete',
+                    tableName: getDynamoDbTableStageName('FEATURES_META', ORG_NAME, STAGE),
+                    key: { scopeAndOwner: buildScopeAndOwnerKey(feature.scope, feature.scopeOwnerId), featureId },
+                },
+            ],
+            origin: 'Feature.deleteFeature',
+        })
     },
 
 }

--- a/services/api/src/models/media-library-item.ts
+++ b/services/api/src/models/media-library-item.ts
@@ -57,6 +57,7 @@ const buildMeta = (item: MediaLibraryImageItem): MediaLibraryImageMeta => ({
     displayName: item.displayName,
     ownerUserId: item.ownerUserId,
     originWorkspaceId: item.originWorkspaceId,
+    sourceFileId: item.sourceFileId,
     scope: item.scope,
     scopeOwnerId: item.scopeOwnerId,
     scopeAndOwner: item.scopeAndOwner,
@@ -77,6 +78,7 @@ const buildVideoMeta = (item: MediaLibraryVideoItem): MediaLibraryVideoMeta => (
     displayName: item.displayName,
     ownerUserId: item.ownerUserId,
     originWorkspaceId: item.originWorkspaceId,
+    sourceFileId: item.sourceFileId,
     scope: item.scope,
     scopeOwnerId: item.scopeOwnerId,
     scopeAndOwner: item.scopeAndOwner,
@@ -109,35 +111,15 @@ export default {
             updatedAt: item.updatedAt,
         }
 
-        await dynamoDBService.putItem({
-            tableName: itemTableName(),
-            item,
+        // All three rows commit or fail together — atomicity is the database's job.
+        await dynamoDBService.transactWrite({
+            operations: [
+                { type: 'put', tableName: itemTableName(), item },
+                { type: 'put', tableName: metaTableName(), item: meta },
+                { type: 'put', tableName: accessListTableName(), item: ownerAccess },
+            ],
             origin: 'MediaLibraryItem.createImageItem',
         })
-        try {
-            await dynamoDBService.putItem({
-                tableName: metaTableName(),
-                item: meta,
-                origin: 'MediaLibraryItem.createImageItem:meta',
-            })
-            await dynamoDBService.putItem({
-                tableName: accessListTableName(),
-                item: ownerAccess,
-                origin: 'MediaLibraryItem.createImageItem:accessList',
-            })
-        } catch (error) {
-            await dynamoDBService.deleteItems({
-                tableName: itemTableName(),
-                key: { itemId: item.itemId, version: item.version },
-                origin: 'MediaLibraryItem.createImageItem:rollback',
-            }).catch(() => {})
-            await dynamoDBService.deleteItems({
-                tableName: metaTableName(),
-                key: { itemId: item.itemId },
-                origin: 'MediaLibraryItem.createImageItem:metaRollback',
-            }).catch(() => {})
-            throw error
-        }
 
         return item
     },
@@ -204,10 +186,8 @@ export default {
             for (const scopeOwnerId of scopeOwnerIds[scope] ?? []) {
                 const result = await dynamoDBService.queryItems({
                     tableName: metaTableName(),
-                    indexName: 'scopeAndOwner',
                     keyConditions: { scopeAndOwner: buildMediaLibraryScopeAndOwnerKey(scope, scopeOwnerId) },
                     fetchAllItems: true,
-                    scanIndexForward: false,
                     origin: `MediaLibraryItem.listAvailable(${scope})`,
                 })
                 records.push(...(result?.items ?? []) as MediaLibraryMeta[])
@@ -223,20 +203,13 @@ export default {
     },
 
     deleteImageItem: async ({ item }: { item: MediaLibraryImageItem }): Promise<void> => {
-        await dynamoDBService.deleteItems({
-            tableName: itemTableName(),
-            key: { itemId: item.itemId, version: item.version },
+        await dynamoDBService.transactWrite({
+            operations: [
+                { type: 'delete', tableName: itemTableName(), key: { itemId: item.itemId, version: item.version } },
+                { type: 'delete', tableName: metaTableName(), key: { scopeAndOwner: item.scopeAndOwner, itemId: item.itemId } },
+                { type: 'delete', tableName: accessListTableName(), key: { principalId: item.ownerUserId, itemId: item.itemId } },
+            ],
             origin: 'MediaLibraryItem.deleteImageItem',
-        })
-        await dynamoDBService.deleteItems({
-            tableName: metaTableName(),
-            key: { itemId: item.itemId },
-            origin: 'MediaLibraryItem.deleteImageItem:meta',
-        })
-        await dynamoDBService.deleteItems({
-            tableName: accessListTableName(),
-            key: { principalId: item.ownerUserId, itemId: item.itemId },
-            origin: 'MediaLibraryItem.deleteImageItem:accessList',
         })
     },
 
@@ -251,19 +224,25 @@ export default {
         sourceFileId: string
         userId: string
     }): Promise<MediaLibraryImageItem | undefined> => {
+        // The meta projection carries sourceFileId precisely so dedup can run
+        // against the scope partition; the full body is a point read after a hit.
         const result = await dynamoDBService.queryItems({
-            tableName: itemTableName(),
-            indexName: 'scopeAndOwner',
+            tableName: metaTableName(),
             keyConditions: { scopeAndOwner: buildMediaLibraryScopeAndOwnerKey(MEDIA_LIBRARY_SCOPE.ORGANIZATION, organizationId) },
             fetchAllItems: true,
-            scanIndexForward: false,
             origin: `MediaLibraryItem.findActiveOrgImageBySource(${organizationId})`,
         })
-        return ((result?.items ?? []) as MediaLibraryImageItem[])
+        const match = ((result?.items ?? []) as MediaLibraryMeta[])
             .find((existing) => existing.status === MEDIA_LIBRARY_ITEM_STATUS.ACTIVE
                 && existing.kind === 'image'
                 && existing.sourceFileId === sourceFileId
                 && existing.ownerUserId === userId)
+        if (!match) return undefined
+        return await dynamoDBService.getItem({
+            tableName: itemTableName(),
+            key: { itemId: match.itemId, version: 1 },
+            origin: `MediaLibraryItem.findActiveOrgImageBySource(${organizationId}):item`,
+        }) as MediaLibraryImageItem | undefined
     },
 
     // =============================================================================
@@ -281,35 +260,15 @@ export default {
             updatedAt: item.updatedAt,
         }
 
-        await dynamoDBService.putItem({
-            tableName: itemTableName(),
-            item,
+        // All three rows commit or fail together — atomicity is the database's job.
+        await dynamoDBService.transactWrite({
+            operations: [
+                { type: 'put', tableName: itemTableName(), item },
+                { type: 'put', tableName: metaTableName(), item: meta },
+                { type: 'put', tableName: accessListTableName(), item: ownerAccess },
+            ],
             origin: 'MediaLibraryItem.createVideoItem',
         })
-        try {
-            await dynamoDBService.putItem({
-                tableName: metaTableName(),
-                item: meta,
-                origin: 'MediaLibraryItem.createVideoItem:meta',
-            })
-            await dynamoDBService.putItem({
-                tableName: accessListTableName(),
-                item: ownerAccess,
-                origin: 'MediaLibraryItem.createVideoItem:accessList',
-            })
-        } catch (error) {
-            await dynamoDBService.deleteItems({
-                tableName: itemTableName(),
-                key: { itemId: item.itemId, version: item.version },
-                origin: 'MediaLibraryItem.createVideoItem:rollback',
-            }).catch(() => {})
-            await dynamoDBService.deleteItems({
-                tableName: metaTableName(),
-                key: { itemId: item.itemId },
-                origin: 'MediaLibraryItem.createVideoItem:metaRollback',
-            }).catch(() => {})
-            throw error
-        }
 
         return item
     },
@@ -412,20 +371,13 @@ export default {
     },
 
     deleteVideoItem: async ({ item }: { item: MediaLibraryVideoItem }): Promise<void> => {
-        await dynamoDBService.deleteItems({
-            tableName: itemTableName(),
-            key: { itemId: item.itemId, version: item.version },
+        await dynamoDBService.transactWrite({
+            operations: [
+                { type: 'delete', tableName: itemTableName(), key: { itemId: item.itemId, version: item.version } },
+                { type: 'delete', tableName: metaTableName(), key: { scopeAndOwner: item.scopeAndOwner, itemId: item.itemId } },
+                { type: 'delete', tableName: accessListTableName(), key: { principalId: item.ownerUserId, itemId: item.itemId } },
+            ],
             origin: 'MediaLibraryItem.deleteVideoItem',
-        })
-        await dynamoDBService.deleteItems({
-            tableName: metaTableName(),
-            key: { itemId: item.itemId },
-            origin: 'MediaLibraryItem.deleteVideoItem:meta',
-        })
-        await dynamoDBService.deleteItems({
-            tableName: accessListTableName(),
-            key: { principalId: item.ownerUserId, itemId: item.itemId },
-            origin: 'MediaLibraryItem.deleteVideoItem:accessList',
         })
     },
 
@@ -438,18 +390,23 @@ export default {
         sourceFileId: string
         userId: string
     }): Promise<MediaLibraryVideoItem | undefined> => {
+        // Same meta-partition dedup path as the image lookup.
         const result = await dynamoDBService.queryItems({
-            tableName: itemTableName(),
-            indexName: 'scopeAndOwner',
+            tableName: metaTableName(),
             keyConditions: { scopeAndOwner: buildMediaLibraryScopeAndOwnerKey(MEDIA_LIBRARY_SCOPE.ORGANIZATION, organizationId) },
             fetchAllItems: true,
-            scanIndexForward: false,
             origin: `MediaLibraryItem.findActiveOrgVideoBySource(${organizationId})`,
         })
-        return ((result?.items ?? []) as MediaLibraryItem[])
-            .filter((it): it is MediaLibraryVideoItem => it.kind === 'video')
+        const match = ((result?.items ?? []) as MediaLibraryMeta[])
             .find((existing) => existing.status === MEDIA_LIBRARY_ITEM_STATUS.ACTIVE
+                && existing.kind === 'video'
                 && existing.sourceFileId === sourceFileId
                 && existing.ownerUserId === userId)
+        if (!match) return undefined
+        return await dynamoDBService.getItem({
+            tableName: itemTableName(),
+            key: { itemId: match.itemId, version: 1 },
+            origin: `MediaLibraryItem.findActiveOrgVideoBySource(${organizationId}):item`,
+        }) as MediaLibraryVideoItem | undefined
     },
 }

--- a/services/api/src/models/organization.ts
+++ b/services/api/src/models/organization.ts
@@ -11,7 +11,23 @@ const {
     STAGE
 } = process.env
 
-export default {
+// Internal loader that keeps the accessList map — permission checks and the
+// access-list fan-out need it; getOrganization strips it before returning.
+const getOrganizationRecord = async (organizationId: string): Promise<Record<string, any> | null> => {
+    const org = await dynamoDBService.getItem({
+        tableName: getDynamoDbTableStageName('ORGANIZATIONS', ORG_NAME, STAGE),
+        key: { organizationId },
+        origin: 'model::Organization->getRecord()'
+    })
+
+    if (!org || Object.keys(org).length === 0) {
+        return null
+    }
+
+    return org
+}
+
+const OrganizationModel = {
     getOrganization: async ({
         organizationId,
         userId
@@ -87,23 +103,26 @@ export default {
         }
 
         try {
-            // Insert the new organization data into the database
-            await dynamoDBService.putItem({
-                tableName: getDynamoDbTableStageName('ORGANIZATIONS', ORG_NAME, STAGE),
-                item: newOrgData,
-                origin: 'createOrganization'
-            })
-
-            // Insert the new organization access list into the database
-            await dynamoDBService.putItem({
-                tableName: getDynamoDbTableStageName('ORGANIZATIONS_ACCESS_LIST', ORG_NAME, STAGE),
-                item: {
-                    userId: userId,    // Partition key
-                    organizationId,    // Sort key
-                    accessLevel,
-                    createdAt: currentDate,
-                    updatedAt: currentDate
-                },
+            // Organization row + owner's access-list row commit or fail together
+            await dynamoDBService.transactWrite({
+                operations: [
+                    {
+                        type: 'put',
+                        tableName: getDynamoDbTableStageName('ORGANIZATIONS', ORG_NAME, STAGE),
+                        item: newOrgData
+                    },
+                    {
+                        type: 'put',
+                        tableName: getDynamoDbTableStageName('ORGANIZATIONS_ACCESS_LIST', ORG_NAME, STAGE),
+                        item: {
+                            userId: userId,    // Partition key
+                            organizationId,    // Sort key
+                            accessLevel,
+                            createdAt: currentDate,
+                            updatedAt: currentDate
+                        }
+                    }
+                ],
                 origin: 'createOrganization'
             })
 
@@ -122,9 +141,12 @@ export default {
         const currentDate = new Date().getTime()
 
         try {
-            const org = await this.getOrganization({ organizationId, userId })
-            if (org.error) {
-                return org
+            const org = await getOrganizationRecord(organizationId)
+            if (!org) {
+                return { error: 'NOT_FOUND' }
+            }
+            if (!org.accessList?.[userId]) {
+                return { error: 'PERMISSION_DENIED' }
             }
 
             const updates = {
@@ -151,38 +173,34 @@ export default {
         userId
     }: Pick<Organization, 'organizationId'> & { userId: string }): Promise<{ status: string; organizationId: string } | { error: string }> => {
         try {
-            const org = await this.getOrganization({ organizationId, userId })
-            if (org.error) {
-                return org
+            const org = await getOrganizationRecord(organizationId)
+            if (!org) {
+                return { error: 'NOT_FOUND' }
             }
 
-            if (org.accessList[userId] !== 'owner') {
+            if (org.accessList?.[userId] !== 'owner') {
                 return { error: 'PERMISSION_DENIED' }
             }
 
-            // Delete the organization
-            await dynamoDBService.deleteItems({
-                tableName: getDynamoDbTableStageName('ORGANIZATIONS', ORG_NAME, STAGE),
-                key: { organizationId },
-                origin: 'deleteOrganization:Organizations'
-            })
+            // The org row's accessList map names every member whose access-list
+            // row must go. Delete the org and all member rows in one transaction.
+            const memberIds = Object.keys(org.accessList ?? {})
 
-            // Delete all access list entries for this organization
-            const accessListEntries = await dynamoDBService.queryItems({
-                tableName: getDynamoDbTableStageName('ORGANIZATIONS_ACCESS_LIST', ORG_NAME, STAGE),
-                indexName: 'organizationId',
-                keyConditions: { organizationId },
-                fetchAllItems: true,
-                origin: 'deleteOrganization:AccessList',
+            await dynamoDBService.transactWrite({
+                operations: [
+                    {
+                        type: 'delete',
+                        tableName: getDynamoDbTableStageName('ORGANIZATIONS', ORG_NAME, STAGE),
+                        key: { organizationId }
+                    },
+                    ...memberIds.map((memberId) => ({
+                        type: 'delete' as const,
+                        tableName: getDynamoDbTableStageName('ORGANIZATIONS_ACCESS_LIST', ORG_NAME, STAGE),
+                        key: { userId: memberId, organizationId }
+                    }))
+                ],
+                origin: 'deleteOrganization'
             })
-
-            for (const entry of accessListEntries.items) {
-                await dynamoDBService.deleteItems({
-                    tableName: getDynamoDbTableStageName('ORGANIZATIONS_ACCESS_LIST', ORG_NAME, STAGE),
-                    key: { userId: entry.userId, organizationId },
-                    origin: 'deleteOrganization:AccessList'
-                })
-            }
 
             return { status: 'deleted', organizationId }
         } catch (e) {
@@ -200,37 +218,40 @@ export default {
         const currentDate = new Date().getTime()
 
         try {
-            const org = await this.getOrganization({ organizationId, userId: addedByUserId })
-            if (org.error) {
-                return org
+            const org = await getOrganizationRecord(organizationId)
+            if (!org) {
+                return { error: 'NOT_FOUND' }
             }
 
-            if (org.accessList[addedByUserId] !== 'owner') {
+            if (org.accessList?.[addedByUserId] !== 'owner') {
                 return { error: 'PERMISSION_DENIED' }
             }
 
-            // Update Organizations table
-            await dynamoDBService.updateItem({
-                tableName: getDynamoDbTableStageName('ORGANIZATIONS', ORG_NAME, STAGE),
-                key: { organizationId },
-                updates: {
-                    [`accessList.${userId}`]: accessLevel,
-                    updatedAt: currentDate
-                },
-                origin: 'addUserToOrganization:Organizations'
-            })
-
-            // Add entry to Organizations-Access-List table
-            await dynamoDBService.putItem({
-                tableName: getDynamoDbTableStageName('ORGANIZATIONS_ACCESS_LIST', ORG_NAME, STAGE),
-                item: {
-                    userId: userId,    // Partition key
-                    organizationId,    // Sort key
-                    accessLevel,
-                    createdAt: currentDate,
-                    updatedAt: currentDate
-                },
-                origin: 'addUserToOrganization:AccessList'
+            // Org row accessList map + member's access-list row commit together
+            await dynamoDBService.transactWrite({
+                operations: [
+                    {
+                        type: 'update',
+                        tableName: getDynamoDbTableStageName('ORGANIZATIONS', ORG_NAME, STAGE),
+                        key: { organizationId },
+                        updates: {
+                            [`accessList.${userId}`]: accessLevel,
+                            updatedAt: currentDate
+                        }
+                    },
+                    {
+                        type: 'put',
+                        tableName: getDynamoDbTableStageName('ORGANIZATIONS_ACCESS_LIST', ORG_NAME, STAGE),
+                        item: {
+                            userId: userId,    // Partition key
+                            organizationId,    // Sort key
+                            accessLevel,
+                            createdAt: currentDate,
+                            updatedAt: currentDate
+                        }
+                    }
+                ],
+                origin: 'addUserToOrganization'
             })
 
             return { status: 'added', userId, organizationId, accessLevel }
@@ -248,31 +269,34 @@ export default {
         const currentDate = new Date().getTime()
 
         try {
-            const org = await this.getOrganization({ organizationId, userId: removedByUserId })
-            if (org.error) {
-                return org
+            const org = await getOrganizationRecord(organizationId)
+            if (!org) {
+                return { error: 'NOT_FOUND' }
             }
 
-            if (org.accessList[removedByUserId] !== 'owner' && removedByUserId !== userId) {
+            if (org.accessList?.[removedByUserId] !== 'owner' && removedByUserId !== userId) {
                 return { error: 'PERMISSION_DENIED' }
             }
 
-            // Update Organizations table
-            await dynamoDBService.updateItem({
-                tableName: getDynamoDbTableStageName('ORGANIZATIONS', ORG_NAME, STAGE),
-                key: { organizationId },
-                updates: {
-                    [`accessList.${userId}`]: null,
-                    updatedAt: currentDate
-                },
-                origin: 'removeUserFromOrganization:Organizations'
-            })
-
-            // Remove entry from Organizations-Access-List table
-            await dynamoDBService.deleteItems({
-                tableName: getDynamoDbTableStageName('ORGANIZATIONS_ACCESS_LIST', ORG_NAME, STAGE),
-                key: { userId: userId, organizationId },
-                origin: 'removeUserFromOrganization:AccessList'
+            // Org row accessList map + member's access-list row commit together
+            await dynamoDBService.transactWrite({
+                operations: [
+                    {
+                        type: 'update',
+                        tableName: getDynamoDbTableStageName('ORGANIZATIONS', ORG_NAME, STAGE),
+                        key: { organizationId },
+                        updates: {
+                            [`accessList.${userId}`]: null,
+                            updatedAt: currentDate
+                        }
+                    },
+                    {
+                        type: 'delete',
+                        tableName: getDynamoDbTableStageName('ORGANIZATIONS_ACCESS_LIST', ORG_NAME, STAGE),
+                        key: { userId: userId, organizationId }
+                    }
+                ],
+                origin: 'removeUserFromOrganization'
             })
 
             return { status: 'removed', userId, organizationId }
@@ -387,3 +411,5 @@ export default {
         }
     },
 }
+
+export default OrganizationModel

--- a/services/api/src/models/workspace.test.ts
+++ b/services/api/src/models/workspace.test.ts
@@ -8,7 +8,15 @@ import type { ContentDescriptor, DocumentFile } from '@lixpi/constants'
 const dynamo = {
     getItem: vi.fn(),
     updateItem: vi.fn(),
+    transactWrite: vi.fn(),
 }
+
+// Transactions surface a failed per-item condition as a cancelled transaction,
+// not as ConditionalCheckFailedException.
+const transactionalConditionalFailure = (message: string) => Object.assign(new Error(message), {
+    name: 'TransactionCanceledException',
+    CancellationReasons: [{ Code: 'ConditionalCheckFailed' }, { Code: 'None' }],
+})
 
 beforeEach(() => {
     vi.useRealTimers()
@@ -81,7 +89,7 @@ describe('Workspace.patchCanvasNodeDescriptor', () => {
                 ],
             },
         })
-        dynamo.updateItem.mockResolvedValue(undefined)
+        dynamo.transactWrite.mockResolvedValue(undefined)
 
         await expect(Workspace.patchCanvasNodeDescriptor({
             workspaceId: 'workspace-1',
@@ -89,7 +97,10 @@ describe('Workspace.patchCanvasNodeDescriptor', () => {
             descriptor,
         })).resolves.toBe(true)
 
-        expect(dynamo.updateItem).toHaveBeenCalledWith(expect.objectContaining({
+        expect(dynamo.transactWrite).toHaveBeenCalledTimes(1)
+        const { operations } = dynamo.transactWrite.mock.calls[0][0]
+        expect(operations[0]).toEqual(expect.objectContaining({
+            type: 'update',
             key: { workspaceId: 'workspace-1' },
             updateExpression: 'SET #canvasState.#nodes[1].#descriptor = :descriptor, #updatedAt = :updatedAt, #canvasStateUpdatedAt = :canvasStateUpdatedAt',
             conditionExpression: '#canvasState.#nodes[1].#nodeId = :nodeId',
@@ -97,6 +108,11 @@ describe('Workspace.patchCanvasNodeDescriptor', () => {
                 ':descriptor': descriptor,
                 ':nodeId': 'node-b',
             }),
+        }))
+        expect(operations[1]).toEqual(expect.objectContaining({
+            type: 'update',
+            tableName: expect.stringContaining('Workspaces-Meta'),
+            updates: { updatedAt: expect.any(Number) },
         }))
     })
 
@@ -121,7 +137,7 @@ describe('Workspace.patchCanvasNodeDescriptor', () => {
             },
         })).resolves.toBe(false)
 
-        expect(dynamo.updateItem).not.toHaveBeenCalled()
+        expect(dynamo.transactWrite).not.toHaveBeenCalled()
     })
 })
 
@@ -140,7 +156,7 @@ describe('Workspace.mutateCanvasState', () => {
                 edges: [],
             },
         })
-        dynamo.updateItem.mockResolvedValue(undefined)
+        dynamo.transactWrite.mockResolvedValue(undefined)
 
         const changed = await Workspace.mutateCanvasState({
             workspaceId: 'workspace-1',
@@ -155,8 +171,11 @@ describe('Workspace.mutateCanvasState', () => {
         })
 
         expect(changed).toBe(true)
-        expect(dynamo.updateItem).toHaveBeenCalledTimes(2)
-        expect(dynamo.updateItem.mock.calls[0][0]).toEqual(expect.objectContaining({
+        expect(dynamo.transactWrite).toHaveBeenCalledTimes(1)
+        const { operations, origin } = dynamo.transactWrite.mock.calls[0][0]
+        expect(origin).toBe('testCanvasMutation')
+        expect(operations[0]).toEqual(expect.objectContaining({
+            type: 'update',
             tableName: expect.stringContaining('Workspaces'),
             key: { workspaceId: 'workspace-1' },
             updateExpression: 'SET #canvasState = :canvasState, #updatedAt = :updatedAt, #canvasStateUpdatedAt = :canvasStateUpdatedAt',
@@ -176,13 +195,12 @@ describe('Workspace.mutateCanvasState', () => {
                 ':updatedAt': expect.any(Number),
                 ':canvasStateUpdatedAt': expect.any(Number),
             }),
-            origin: 'testCanvasMutation',
         }))
-        expect(dynamo.updateItem.mock.calls[1][0]).toEqual(expect.objectContaining({
+        expect(operations[1]).toEqual(expect.objectContaining({
+            type: 'update',
             tableName: expect.stringContaining('Workspaces-Meta'),
             key: { workspaceId: 'workspace-1' },
             updates: { updatedAt: expect.any(Number) },
-            origin: 'testCanvasMutation:meta',
         }))
     })
 
@@ -202,7 +220,7 @@ describe('Workspace.mutateCanvasState', () => {
         })
 
         expect(changed).toBe(false)
-        expect(dynamo.updateItem).not.toHaveBeenCalled()
+        expect(dynamo.transactWrite).not.toHaveBeenCalled()
     })
 
     it('uses legacy updatedAt as the canvas save token when canvasStateUpdatedAt is missing', async () => {
@@ -214,7 +232,7 @@ describe('Workspace.mutateCanvasState', () => {
                 edges: [],
             },
         })
-        dynamo.updateItem.mockResolvedValue(undefined)
+        dynamo.transactWrite.mockResolvedValue(undefined)
 
         await Workspace.mutateCanvasState({
             workspaceId: 'workspace-1',
@@ -227,7 +245,7 @@ describe('Workspace.mutateCanvasState', () => {
             }),
         })
 
-        expect(dynamo.updateItem.mock.calls[0][0]).toEqual(expect.objectContaining({
+        expect(dynamo.transactWrite.mock.calls[0][0].operations[0]).toEqual(expect.objectContaining({
             conditionExpression: '(#canvasStateUpdatedAt = :expectedCanvasStateUpdatedAt OR (attribute_not_exists(#canvasStateUpdatedAt) AND #updatedAt = :expectedCanvasStateUpdatedAt))',
             expressionAttributeValues: expect.objectContaining({
                 ':expectedCanvasStateUpdatedAt': 10,
@@ -243,7 +261,7 @@ describe('Workspace.mutateCanvasState', () => {
                 edges: [],
             },
         })
-        dynamo.updateItem.mockResolvedValue(undefined)
+        dynamo.transactWrite.mockResolvedValue(undefined)
 
         await Workspace.mutateCanvasState({
             workspaceId: 'workspace-1',
@@ -256,7 +274,7 @@ describe('Workspace.mutateCanvasState', () => {
             }),
         })
 
-        expect(dynamo.updateItem.mock.calls[0][0]).toEqual(expect.objectContaining({
+        expect(dynamo.transactWrite.mock.calls[0][0].operations[0]).toEqual(expect.objectContaining({
             conditionExpression: '(attribute_not_exists(#canvasStateUpdatedAt) AND attribute_not_exists(#updatedAt))',
             expressionAttributeValues: expect.not.objectContaining({
                 ':expectedCanvasStateUpdatedAt': expect.anything(),
@@ -265,9 +283,7 @@ describe('Workspace.mutateCanvasState', () => {
     })
 
     it('re-reads and retries when a concurrent canvas write wins the canvasStateUpdatedAt condition', async () => {
-        const conditionalFailure = Object.assign(new Error('stale canvas write'), {
-            name: 'ConditionalCheckFailedException',
-        })
+        const conditionalFailure = transactionalConditionalFailure('stale canvas write')
         dynamo.getItem
             .mockResolvedValueOnce({
                 updatedAt: 10,
@@ -287,9 +303,8 @@ describe('Workspace.mutateCanvasState', () => {
                     edges: [],
                 },
             })
-        dynamo.updateItem
+        dynamo.transactWrite
             .mockRejectedValueOnce(conditionalFailure)
-            .mockResolvedValueOnce(undefined)
             .mockResolvedValueOnce(undefined)
 
         const changed = await Workspace.mutateCanvasState({
@@ -309,10 +324,10 @@ describe('Workspace.mutateCanvasState', () => {
 
         expect(changed).toBe(true)
         expect(dynamo.getItem).toHaveBeenCalledTimes(2)
-        expect(dynamo.updateItem).toHaveBeenCalledTimes(3)
-        expect(dynamo.updateItem.mock.calls[0][0].expressionAttributeValues[':expectedCanvasStateUpdatedAt']).toBe(5)
-        expect(dynamo.updateItem.mock.calls[1][0].expressionAttributeValues[':expectedCanvasStateUpdatedAt']).toBe(6)
-        expect(dynamo.updateItem.mock.calls[1][0].expressionAttributeValues[':canvasState'].nodes).toEqual([
+        expect(dynamo.transactWrite).toHaveBeenCalledTimes(2)
+        expect(dynamo.transactWrite.mock.calls[0][0].operations[0].expressionAttributeValues[':expectedCanvasStateUpdatedAt']).toBe(5)
+        expect(dynamo.transactWrite.mock.calls[1][0].operations[0].expressionAttributeValues[':expectedCanvasStateUpdatedAt']).toBe(6)
+        expect(dynamo.transactWrite.mock.calls[1][0].operations[0].expressionAttributeValues[':canvasState'].nodes).toEqual([
             expect.objectContaining({ nodeId: 'concurrent-node' }),
             expect.objectContaining({ nodeId: 'projection-node' }),
         ])
@@ -325,7 +340,7 @@ describe('Workspace.mutateCanvasState', () => {
 
 describe('Workspace.updateCanvasState', () => {
     it('writes full canvas state with a canvasStateUpdatedAt condition when the client supplies a save token', async () => {
-        dynamo.updateItem.mockResolvedValue(undefined)
+        dynamo.transactWrite.mockResolvedValue(undefined)
 
         const result = await Workspace.updateCanvasState({
             userId: 'user-1',
@@ -344,7 +359,11 @@ describe('Workspace.updateCanvasState', () => {
             updatedAt: expect.any(Number),
             canvasStateUpdatedAt: expect.any(Number),
         })
-        expect(dynamo.updateItem).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        expect(dynamo.transactWrite).toHaveBeenCalledTimes(1)
+        const { operations, origin } = dynamo.transactWrite.mock.calls[0][0]
+        expect(origin).toBe('updateWorkspaceCanvasState')
+        expect(operations[0]).toEqual(expect.objectContaining({
+            type: 'update',
             key: { workspaceId: 'workspace-1' },
             updateExpression: 'SET #canvasState = :canvasState, #updatedAt = :updatedAt, #canvasStateUpdatedAt = :canvasStateUpdatedAt',
             conditionExpression: '(#canvasStateUpdatedAt = :expectedCanvasStateUpdatedAt OR (attribute_not_exists(#canvasStateUpdatedAt) AND #updatedAt = :expectedCanvasStateUpdatedAt))',
@@ -360,19 +379,17 @@ describe('Workspace.updateCanvasState', () => {
                 }),
                 ':canvasStateUpdatedAt': expect.any(Number),
             }),
-            origin: 'updateWorkspaceCanvasState',
         }))
-        expect(dynamo.updateItem).toHaveBeenNthCalledWith(2, expect.objectContaining({
+        expect(operations[1]).toEqual(expect.objectContaining({
+            type: 'update',
             tableName: expect.stringContaining('Workspaces-Meta'),
             updates: { updatedAt: expect.any(Number) },
         }))
     })
 
     it('rejects stale full canvas saves instead of overwriting newer canonical state', async () => {
-        const conditionalFailure = Object.assign(new Error('stale canvas write'), {
-            name: 'ConditionalCheckFailedException',
-        })
-        dynamo.updateItem.mockRejectedValueOnce(conditionalFailure)
+        const conditionalFailure = transactionalConditionalFailure('stale canvas write')
+        dynamo.transactWrite.mockRejectedValueOnce(conditionalFailure)
         dynamo.getItem
             .mockResolvedValueOnce({
                 updatedAt: 12,
@@ -399,7 +416,7 @@ describe('Workspace.updateCanvasState', () => {
             currentUpdatedAt: 22,
             currentCanvasStateUpdatedAt: 18,
         })
-        expect(dynamo.updateItem).toHaveBeenCalledTimes(1)
+        expect(dynamo.transactWrite).toHaveBeenCalledTimes(1)
         expect(dynamo.getItem).toHaveBeenCalledWith(expect.objectContaining({
             key: { workspaceId: 'workspace-1' },
             origin: 'updateWorkspaceCanvasState:stale(workspace-1)',
@@ -407,7 +424,7 @@ describe('Workspace.updateCanvasState', () => {
     })
 
     it('allows tokenless full canvas saves only for rows without any canvas token', async () => {
-        dynamo.updateItem.mockResolvedValue(undefined)
+        dynamo.transactWrite.mockResolvedValue(undefined)
 
         await Workspace.updateCanvasState({
             userId: 'user-1',
@@ -419,7 +436,7 @@ describe('Workspace.updateCanvasState', () => {
             },
         })
 
-        expect(dynamo.updateItem).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        expect(dynamo.transactWrite.mock.calls[0][0].operations[0]).toEqual(expect.objectContaining({
             conditionExpression: '(attribute_not_exists(#canvasStateUpdatedAt) AND attribute_not_exists(#updatedAt))',
             expressionAttributeValues: expect.not.objectContaining({
                 ':expectedCanvasStateUpdatedAt': expect.anything(),
@@ -482,7 +499,7 @@ describe('Workspace.updateCanvasState', () => {
                 }],
             },
         })
-        dynamo.updateItem.mockResolvedValue(undefined)
+        dynamo.transactWrite.mockResolvedValue(undefined)
 
         await Workspace.updateCanvasState({
             userId: 'user-1',
@@ -527,7 +544,7 @@ describe('Workspace.updateCanvasState', () => {
             },
         })
 
-        const writtenState = dynamo.updateItem.mock.calls[0]?.[0].expressionAttributeValues[':canvasState']
+        const writtenState = dynamo.transactWrite.mock.calls[0]?.[0].operations[0].expressionAttributeValues[':canvasState']
         expect(writtenState.nodes).toEqual(expect.arrayContaining([
             expect.objectContaining({ nodeId: 'user-node' }),
             expect.objectContaining({ nodeId: 'fork-1' }),
@@ -596,7 +613,7 @@ describe('Workspace.updateCanvasState', () => {
                 }],
             },
         })
-        dynamo.updateItem.mockResolvedValue(undefined)
+        dynamo.transactWrite.mockResolvedValue(undefined)
 
         await Workspace.updateCanvasState({
             userId: 'user-1',
@@ -609,7 +626,7 @@ describe('Workspace.updateCanvasState', () => {
             },
         })
 
-        const writtenState = dynamo.updateItem.mock.calls[0]?.[0].expressionAttributeValues[':canvasState']
+        const writtenState = dynamo.transactWrite.mock.calls[0]?.[0].operations[0].expressionAttributeValues[':canvasState']
         expect(writtenState.nodes).toEqual([
             expect.objectContaining({ nodeId: 'user-node' }),
         ])
@@ -637,7 +654,7 @@ describe('Workspace.updateCanvasState', () => {
                 edges: [],
             },
         })
-        dynamo.updateItem.mockResolvedValue(undefined)
+        dynamo.transactWrite.mockResolvedValue(undefined)
 
         await Workspace.updateCanvasState({
             userId: 'user-1',
@@ -650,7 +667,7 @@ describe('Workspace.updateCanvasState', () => {
             },
         })
 
-        const writtenState = dynamo.updateItem.mock.calls[0]?.[0].expressionAttributeValues[':canvasState']
+        const writtenState = dynamo.transactWrite.mock.calls[0]?.[0].operations[0].expressionAttributeValues[':canvasState']
         expect(writtenState.nodes).toEqual([
             expect.objectContaining({ nodeId: 'user-node' }),
         ])
@@ -676,21 +693,23 @@ describe('Workspace.updateCanvasState', () => {
                 return undefined
             }
 
-            if (params.origin === 'updateWorkspaceCanvasState' && params.updateExpression) {
-                const expectedCanvasStateUpdatedAt = params.expressionAttributeValues[':expectedCanvasStateUpdatedAt']
+            return undefined
+        })
+
+        dynamo.transactWrite.mockImplementation(async ({ operations, origin }: any) => {
+            const canvasOperation = operations[0]
+            if (origin === 'updateWorkspaceCanvasState' && canvasOperation?.updateExpression) {
+                const expectedCanvasStateUpdatedAt = canvasOperation.expressionAttributeValues[':expectedCanvasStateUpdatedAt']
                 const canvasTokenMatches = workspaceItem.canvasStateUpdatedAt === expectedCanvasStateUpdatedAt
                 const legacyTokenMatches = workspaceItem.canvasStateUpdatedAt === undefined && workspaceItem.updatedAt === expectedCanvasStateUpdatedAt
 
                 if (!canvasTokenMatches && !legacyTokenMatches) {
-                    throw Object.assign(new Error('stale canvas write'), {
-                        name: 'ConditionalCheckFailedException',
-                    })
+                    throw transactionalConditionalFailure('stale canvas write')
                 }
 
-                workspaceItem.canvasState = params.expressionAttributeValues[':canvasState']
-                workspaceItem.canvasStateUpdatedAt = params.expressionAttributeValues[':canvasStateUpdatedAt']
-                workspaceItem.updatedAt = params.expressionAttributeValues[':updatedAt']
-                return undefined
+                workspaceItem.canvasState = canvasOperation.expressionAttributeValues[':canvasState']
+                workspaceItem.canvasStateUpdatedAt = canvasOperation.expressionAttributeValues[':canvasStateUpdatedAt']
+                workspaceItem.updatedAt = canvasOperation.expressionAttributeValues[':updatedAt']
             }
 
             return undefined

--- a/services/api/src/models/workspace.ts
+++ b/services/api/src/models/workspace.ts
@@ -14,6 +14,7 @@ import {
     type DocumentFile
 } from '@lixpi/constants'
 import { err } from '@lixpi/debug-tools'
+import { isTransactionConditionalCheckFailure } from '@lixpi/dynamodb-service'
 
 const {
     ORG_NAME,
@@ -373,32 +374,37 @@ export default {
         }
 
         try {
-            await dynamoDBService.putItem({
-                tableName: getDynamoDbTableStageName('WORKSPACES', ORG_NAME, STAGE),
-                item: newWorkspaceData,
-                origin: 'createWorkspace'
-            })
-
-            await dynamoDBService.putItem({
-                tableName: getDynamoDbTableStageName('WORKSPACES_META', ORG_NAME, STAGE),
-                item: {
-                    workspaceId: newWorkspaceData.workspaceId,
-                    name: newWorkspaceData.name,
-                    createdAt: newWorkspaceData.createdAt,
-                    updatedAt: newWorkspaceData.updatedAt
-                },
-                origin: 'createWorkspace'
-            })
-
-            await dynamoDBService.putItem({
-                tableName: getDynamoDbTableStageName('WORKSPACES_ACCESS_LIST', ORG_NAME, STAGE),
-                item: {
-                    userId: permissions.userId,
-                    workspaceId: newWorkspaceData.workspaceId,
-                    accessLevel: permissions.accessLevel,
-                    createdAt: newWorkspaceData.createdAt,
-                    updatedAt: newWorkspaceData.updatedAt
-                },
+            // Main + Meta + Access-List commit or fail together — a torn triad
+            // (workspace invisible to its owner) is a permanent integrity fault.
+            await dynamoDBService.transactWrite({
+                operations: [
+                    {
+                        type: 'put',
+                        tableName: getDynamoDbTableStageName('WORKSPACES', ORG_NAME, STAGE),
+                        item: newWorkspaceData
+                    },
+                    {
+                        type: 'put',
+                        tableName: getDynamoDbTableStageName('WORKSPACES_META', ORG_NAME, STAGE),
+                        item: {
+                            workspaceId: newWorkspaceData.workspaceId,
+                            name: newWorkspaceData.name,
+                            createdAt: newWorkspaceData.createdAt,
+                            updatedAt: newWorkspaceData.updatedAt
+                        }
+                    },
+                    {
+                        type: 'put',
+                        tableName: getDynamoDbTableStageName('WORKSPACES_ACCESS_LIST', ORG_NAME, STAGE),
+                        item: {
+                            userId: permissions.userId,
+                            workspaceId: newWorkspaceData.workspaceId,
+                            accessLevel: permissions.accessLevel,
+                            createdAt: newWorkspaceData.createdAt,
+                            updatedAt: newWorkspaceData.updatedAt
+                        }
+                    }
+                ],
                 origin: 'createWorkspace'
             })
 
@@ -434,26 +440,28 @@ export default {
                 workspaceSetExpressions.push('#name = :name')
             }
 
-            await dynamoDBService.updateItem({
-                tableName: getDynamoDbTableStageName('WORKSPACES', ORG_NAME, STAGE),
-                key: { workspaceId },
-                updateExpression: `SET ${workspaceSetExpressions.join(', ')}`,
-                expressionAttributeNames: workspaceExpressionNames,
-                expressionAttributeValues: workspaceExpressionValues,
+            await dynamoDBService.transactWrite({
+                operations: [
+                    {
+                        type: 'update',
+                        tableName: getDynamoDbTableStageName('WORKSPACES', ORG_NAME, STAGE),
+                        key: { workspaceId },
+                        updateExpression: `SET ${workspaceSetExpressions.join(', ')}`,
+                        expressionAttributeNames: workspaceExpressionNames,
+                        expressionAttributeValues: workspaceExpressionValues
+                    },
+                    ...(name !== undefined ? [{
+                        type: 'update' as const,
+                        tableName: getDynamoDbTableStageName('WORKSPACES_META', ORG_NAME, STAGE),
+                        key: { workspaceId },
+                        updates: {
+                            name,
+                            updatedAt: currentDate
+                        }
+                    }] : [])
+                ],
                 origin: 'updateWorkspace'
             })
-
-            if (name !== undefined) {
-                await dynamoDBService.updateItem({
-                    tableName: getDynamoDbTableStageName('WORKSPACES_META', ORG_NAME, STAGE),
-                    key: { workspaceId },
-                    updates: {
-                        name,
-                        updatedAt: currentDate
-                    },
-                    origin: 'updateWorkspace'
-                })
-            }
         } catch (error) {
             err('Failed to update workspace:', error)
         }
@@ -488,38 +496,42 @@ export default {
                 currentDate
             )
 
-            await dynamoDBService.updateItem({
-                tableName: getDynamoDbTableStageName('WORKSPACES', ORG_NAME, STAGE),
-                key: { workspaceId },
-                updateExpression: 'SET #canvasState = :canvasState, #updatedAt = :updatedAt, #canvasStateUpdatedAt = :canvasStateUpdatedAt',
-                conditionExpression: getCanvasStateWriteCondition(hasExpectedCanvasStateUpdatedAt),
-                expressionAttributeNames: {
-                    '#canvasState': 'canvasState',
-                    '#updatedAt': 'updatedAt',
-                    '#canvasStateUpdatedAt': 'canvasStateUpdatedAt'
-                },
-                expressionAttributeValues: {
-                    ':canvasState': nextCanvasState,
-                    ':updatedAt': currentDate,
-                    ':canvasStateUpdatedAt': currentDate,
-                    ...(hasExpectedCanvasStateUpdatedAt ? { ':expectedCanvasStateUpdatedAt': canvasStateSaveToken } : {})
-                },
+            await dynamoDBService.transactWrite({
+                operations: [
+                    {
+                        type: 'update',
+                        tableName: getDynamoDbTableStageName('WORKSPACES', ORG_NAME, STAGE),
+                        key: { workspaceId },
+                        updateExpression: 'SET #canvasState = :canvasState, #updatedAt = :updatedAt, #canvasStateUpdatedAt = :canvasStateUpdatedAt',
+                        conditionExpression: getCanvasStateWriteCondition(hasExpectedCanvasStateUpdatedAt),
+                        expressionAttributeNames: {
+                            '#canvasState': 'canvasState',
+                            '#updatedAt': 'updatedAt',
+                            '#canvasStateUpdatedAt': 'canvasStateUpdatedAt'
+                        },
+                        expressionAttributeValues: {
+                            ':canvasState': nextCanvasState,
+                            ':updatedAt': currentDate,
+                            ':canvasStateUpdatedAt': currentDate,
+                            ...(hasExpectedCanvasStateUpdatedAt ? { ':expectedCanvasStateUpdatedAt': canvasStateSaveToken } : {})
+                        }
+                    },
+                    {
+                        type: 'update',
+                        tableName: getDynamoDbTableStageName('WORKSPACES_META', ORG_NAME, STAGE),
+                        key: { workspaceId },
+                        updates: {
+                            updatedAt: currentDate
+                        }
+                    }
+                ],
                 logConditionalCheckFailures: false,
-                origin: 'updateWorkspaceCanvasState'
-            })
-
-            await dynamoDBService.updateItem({
-                tableName: getDynamoDbTableStageName('WORKSPACES_META', ORG_NAME, STAGE),
-                key: { workspaceId },
-                updates: {
-                    updatedAt: currentDate
-                },
                 origin: 'updateWorkspaceCanvasState'
             })
 
             return { success: true, workspaceId, updatedAt: currentDate, canvasStateUpdatedAt: currentDate }
         } catch (error) {
-            if ((error as any)?.name === 'ConditionalCheckFailedException') {
+            if (isTransactionConditionalCheckFailure(error)) {
                 const workspace = await dynamoDBService.getItem({
                     tableName: getDynamoDbTableStageName('WORKSPACES', ORG_NAME, STAGE),
                     key: { workspaceId },
@@ -572,32 +584,36 @@ export default {
                     ':canvasStateUpdatedAt': currentDate,
                     ...(hasExpectedCanvasStateUpdatedAt ? { ':expectedCanvasStateUpdatedAt': expectedCanvasStateUpdatedAt } : {})
                 }
-                await dynamoDBService.updateItem({
-                    tableName: getDynamoDbTableStageName('WORKSPACES', ORG_NAME, STAGE),
-                    key: { workspaceId },
-                    updateExpression: 'SET #canvasState = :canvasState, #updatedAt = :updatedAt, #canvasStateUpdatedAt = :canvasStateUpdatedAt',
-                    conditionExpression: getCanvasStateWriteCondition(hasExpectedCanvasStateUpdatedAt),
-                    expressionAttributeNames: {
-                        '#canvasState': 'canvasState',
-                        '#updatedAt': 'updatedAt',
-                        '#canvasStateUpdatedAt': 'canvasStateUpdatedAt'
-                    },
-                    expressionAttributeValues,
+                await dynamoDBService.transactWrite({
+                    operations: [
+                        {
+                            type: 'update',
+                            tableName: getDynamoDbTableStageName('WORKSPACES', ORG_NAME, STAGE),
+                            key: { workspaceId },
+                            updateExpression: 'SET #canvasState = :canvasState, #updatedAt = :updatedAt, #canvasStateUpdatedAt = :canvasStateUpdatedAt',
+                            conditionExpression: getCanvasStateWriteCondition(hasExpectedCanvasStateUpdatedAt),
+                            expressionAttributeNames: {
+                                '#canvasState': 'canvasState',
+                                '#updatedAt': 'updatedAt',
+                                '#canvasStateUpdatedAt': 'canvasStateUpdatedAt'
+                            },
+                            expressionAttributeValues
+                        },
+                        {
+                            type: 'update',
+                            tableName: getDynamoDbTableStageName('WORKSPACES_META', ORG_NAME, STAGE),
+                            key: { workspaceId },
+                            updates: {
+                                updatedAt: currentDate
+                            }
+                        }
+                    ],
                     logConditionalCheckFailures: false,
                     origin
                 })
-
-                await dynamoDBService.updateItem({
-                    tableName: getDynamoDbTableStageName('WORKSPACES_META', ORG_NAME, STAGE),
-                    key: { workspaceId },
-                    updates: {
-                        updatedAt: currentDate
-                    },
-                    origin: `${origin}:meta`
-                })
                 return true
             } catch (error: any) {
-                if (error?.name === 'ConditionalCheckFailedException') continue
+                if (isTransactionConditionalCheckFailure(error)) continue
                 err('Failed to mutate workspace canvas state:', error)
                 throw error
             }
@@ -624,35 +640,39 @@ export default {
             const nodeIndex = nodes.findIndex((node: { nodeId?: string }) => node.nodeId === nodeId)
             if (nodeIndex < 0) return false
 
-            await dynamoDBService.updateItem({
-                tableName: getDynamoDbTableStageName('WORKSPACES', ORG_NAME, STAGE),
-                key: { workspaceId },
-                updateExpression: `SET #canvasState.#nodes[${nodeIndex}].#descriptor = :descriptor, #updatedAt = :updatedAt, #canvasStateUpdatedAt = :canvasStateUpdatedAt`,
-                conditionExpression: `#canvasState.#nodes[${nodeIndex}].#nodeId = :nodeId`,
-                expressionAttributeNames: {
-                    '#canvasState': 'canvasState',
-                    '#nodes': 'nodes',
-                    '#descriptor': 'descriptor',
-                    '#updatedAt': 'updatedAt',
-                    '#canvasStateUpdatedAt': 'canvasStateUpdatedAt',
-                    '#nodeId': 'nodeId'
-                },
-                expressionAttributeValues: {
-                    ':descriptor': descriptor,
-                    ':updatedAt': currentDate,
-                    ':canvasStateUpdatedAt': currentDate,
-                    ':nodeId': nodeId
-                },
+            await dynamoDBService.transactWrite({
+                operations: [
+                    {
+                        type: 'update',
+                        tableName: getDynamoDbTableStageName('WORKSPACES', ORG_NAME, STAGE),
+                        key: { workspaceId },
+                        updateExpression: `SET #canvasState.#nodes[${nodeIndex}].#descriptor = :descriptor, #updatedAt = :updatedAt, #canvasStateUpdatedAt = :canvasStateUpdatedAt`,
+                        conditionExpression: `#canvasState.#nodes[${nodeIndex}].#nodeId = :nodeId`,
+                        expressionAttributeNames: {
+                            '#canvasState': 'canvasState',
+                            '#nodes': 'nodes',
+                            '#descriptor': 'descriptor',
+                            '#updatedAt': 'updatedAt',
+                            '#canvasStateUpdatedAt': 'canvasStateUpdatedAt',
+                            '#nodeId': 'nodeId'
+                        },
+                        expressionAttributeValues: {
+                            ':descriptor': descriptor,
+                            ':updatedAt': currentDate,
+                            ':canvasStateUpdatedAt': currentDate,
+                            ':nodeId': nodeId
+                        }
+                    },
+                    {
+                        type: 'update',
+                        tableName: getDynamoDbTableStageName('WORKSPACES_META', ORG_NAME, STAGE),
+                        key: { workspaceId },
+                        updates: {
+                            updatedAt: currentDate
+                        }
+                    }
+                ],
                 origin: 'patchWorkspaceCanvasNodeDescriptor'
-            })
-
-            await dynamoDBService.updateItem({
-                tableName: getDynamoDbTableStageName('WORKSPACES_META', ORG_NAME, STAGE),
-                key: { workspaceId },
-                updates: {
-                    updatedAt: currentDate
-                },
-                origin: 'patchWorkspaceCanvasNodeDescriptor:meta'
             })
 
             return true
@@ -667,22 +687,25 @@ export default {
         userId
     }: { workspaceId: string; userId: string }): Promise<{ status: string; workspaceId: string }> => {
         try {
-            await dynamoDBService.deleteItems({
-                tableName: getDynamoDbTableStageName('WORKSPACES', ORG_NAME, STAGE),
-                key: { workspaceId },
+            await dynamoDBService.transactWrite({
+                operations: [
+                    {
+                        type: 'delete',
+                        tableName: getDynamoDbTableStageName('WORKSPACES', ORG_NAME, STAGE),
+                        key: { workspaceId }
+                    },
+                    {
+                        type: 'delete',
+                        tableName: getDynamoDbTableStageName('WORKSPACES_META', ORG_NAME, STAGE),
+                        key: { workspaceId }
+                    },
+                    {
+                        type: 'delete',
+                        tableName: getDynamoDbTableStageName('WORKSPACES_ACCESS_LIST', ORG_NAME, STAGE),
+                        key: { userId, workspaceId }
+                    }
+                ],
                 origin: 'deleteWorkspace'
-            })
-
-            await dynamoDBService.deleteItems({
-                tableName: getDynamoDbTableStageName('WORKSPACES_META', ORG_NAME, STAGE),
-                key: { workspaceId },
-                origin: 'deleteWorkspace:Meta'
-            })
-
-            await dynamoDBService.deleteItems({
-                tableName: getDynamoDbTableStageName('WORKSPACES_ACCESS_LIST', ORG_NAME, STAGE),
-                key: { userId, workspaceId },
-                origin: 'deleteWorkspace:AccessList'
             })
 
             return { status: 'deleted', workspaceId }
@@ -891,25 +914,29 @@ export default {
         const currentDate = new Date().getTime()
 
         try {
-            await dynamoDBService.updateItem({
-                tableName: getDynamoDbTableStageName('WORKSPACES', ORG_NAME, STAGE),
-                key: { workspaceId },
-                updates: {
-                    canvasState,
-                    files,
-                    canvasStateUpdatedAt: currentDate,
-                    updatedAt: currentDate
-                },
+            await dynamoDBService.transactWrite({
+                operations: [
+                    {
+                        type: 'update',
+                        tableName: getDynamoDbTableStageName('WORKSPACES', ORG_NAME, STAGE),
+                        key: { workspaceId },
+                        updates: {
+                            canvasState,
+                            files,
+                            canvasStateUpdatedAt: currentDate,
+                            updatedAt: currentDate
+                        }
+                    },
+                    {
+                        type: 'update',
+                        tableName: getDynamoDbTableStageName('WORKSPACES_META', ORG_NAME, STAGE),
+                        key: { workspaceId },
+                        updates: {
+                            updatedAt: currentDate
+                        }
+                    }
+                ],
                 origin: 'replaceWorkspaceContent'
-            })
-
-            await dynamoDBService.updateItem({
-                tableName: getDynamoDbTableStageName('WORKSPACES_META', ORG_NAME, STAGE),
-                key: { workspaceId },
-                updates: {
-                    updatedAt: currentDate
-                },
-                origin: 'replaceWorkspaceContent:meta'
             })
         } catch (error) {
             err('Failed to replace workspace content:', error)

--- a/services/web-ui/src/components/WorkspaceCanvas.svelte
+++ b/services/web-ui/src/components/WorkspaceCanvas.svelte
@@ -37,7 +37,6 @@
         workspaceId: string
         documentId: string
         title?: string
-        prevRevision?: number
         content?: any
     }
 
@@ -134,7 +133,6 @@
             workspaceId: targetWorkspaceId,
             documentId,
             ...(update.title !== undefined ? { title: update.title } : {}),
-            ...(update.prevRevision !== undefined ? { prevRevision: update.prevRevision } : {}),
             ...(update.content !== undefined ? { content: update.content } : {}),
         }
         pendingDocumentUpdates.set(documentId, pendingUpdate)
@@ -533,12 +531,11 @@
             aiChatThreads,
             onViewportChange: handleViewportChange,
             onCanvasStateChange: persistCanvasState,
-            onDocumentContentChange: ({ documentId, title, prevRevision, content }) => {
+            onDocumentContentChange: ({ documentId, title, content }) => {
                 if (!workspaceId || loadedWorkspaceId !== workspaceId) return
                 scheduleDocumentUpdate({
                     workspaceId,
                     documentId,
-                    prevRevision: prevRevision || 1,
                     content
                 })
             },

--- a/services/web-ui/src/infographics/workspace/WorkspaceCanvas.ts
+++ b/services/web-ui/src/infographics/workspace/WorkspaceCanvas.ts
@@ -817,7 +817,7 @@ type DragStartOptions = {
 type WorkspaceCanvasCallbacks = {
     onViewportChange?: (viewport: Viewport) => void
     onCanvasStateChange?: (state: CanvasState) => void
-    onDocumentContentChange?: (params: { documentId: string; title?: string; prevRevision?: number; content: any }) => void
+    onDocumentContentChange?: (params: { documentId: string; title?: string; content: any }) => void
     onDocumentTitleChange?: (params: { documentId: string; title: string }) => void
     onAiChatThreadContentChange?: (params: { workspaceId: string; threadId: string; content: any }) => void
 }
@@ -12557,7 +12557,6 @@ export function createWorkspaceCanvas(options: WorkspaceCanvasOptions) {
                         onDocumentContentChange?.({
                             documentId: node.referenceId,
                             title: doc.title,
-                            prevRevision: doc.prevRevision || 1,
                             content: value
                         })
                     },

--- a/services/web-ui/src/services/document-service.ts
+++ b/services/web-ui/src/services/document-service.ts
@@ -100,7 +100,7 @@ class DocumentService {
 	}
 
 
-	public async updateDocument({ workspaceId, documentId, title, prevRevision, content }: { workspaceId?: string; documentId: string; title?: string; prevRevision?: number; content?: any }): Promise<void> {
+	public async updateDocument({ workspaceId, documentId, title, content }: { workspaceId?: string; documentId: string; title?: string; content?: any }): Promise<void> {
 		try {
 			const updatePayload: any = {
 				token: await AuthService.getTokenSilently(),
@@ -108,7 +108,6 @@ class DocumentService {
 			}
 			if (workspaceId) updatePayload.workspaceId = workspaceId
 			if (title !== undefined) updatePayload.title = title
-			if (prevRevision !== undefined) updatePayload.prevRevision = prevRevision
 			if (content !== undefined) updatePayload.content = content
 
 			const documentUpdateResult: any = await servicesStore.getData('nats')!.request(DOCUMENT_SUBJECTS.UPDATE_DOCUMENT, updatePayload)

--- a/services/web-ui/src/stores/documentStore.ts
+++ b/services/web-ui/src/stores/documentStore.ts
@@ -19,8 +19,6 @@ type Meta = {
 export type Document = {
     documentId: string
     title: string
-    revision?: number
-    prevRevision?: number
     proseMirrorVersion?: number
     content?: Record<string, any>
     tags?: Tag[]
@@ -45,8 +43,6 @@ const document: DocumentStore = {
     data: {
         documentId: '',
         title: '',
-        revision: 0,
-        prevRevision: 0,
         content: {},
         createdAt: '',
         updatedAt: '',


### PR DESCRIPTION
Closes #301

## Summary

Implements `documentation/memory/ELIMINATE-DYNAMODB-GSIS.md` and removes the vestigial document revision functionality.

### Zero GSIs — scope-partitioned base tables

- `Documents` re-keyed to PK `workspaceId` / SK `documentId`; `Media-Library-Items-Meta` to PK `scopeAndOwner` / SK `itemId`; `Features-Meta` to PK `scopeAndOwner` / SK `featureId`. All four `globalSecondaryIndexes` blocks deleted from the table definitions (`local-dynamodb-init.ts` inherits via `getTableDefinitions()`).
- Every list is now a single-partition base-table `Query`: workspace documents, org media, org features, workspace-deletion teardown. Recency ordering is an in-memory `updatedAt` sort over the partition.
- Media save-time dedup runs against the meta partition — the meta projection now carries `sourceFileId` — followed by a point read of the body.

### Transactional multi-table writes

- New typed `transactWrite({ operations, origin })` on `DynamoDBService` accepting the same shapes as `putItem`/`updateItem`/`deleteItems`, incl. custom update/condition expressions; the caller-less raw `transactWriteItems` pass-through is deleted. `isTransactionConditionalCheckFailure()` lets the canvas optimistic-concurrency retries handle `TransactionCanceledException`.
- Every multi-table write in `workspace`, `organization`, `document`, `media-library-item`, and `feature` models is now one atomic transaction. The hand-rolled compensating rollback in media creates is deleted.
- `deleteOrganization` fixed: it queried a nonexistent `organizationId` GSI (throwing at runtime); it now derives members from the org row's `accessList` map and deletes the org plus all member access-list rows in one transaction. Also repaired broken `this.` references in the organization model.
- Dead `Document.addFile`/`Document.removeFile` removed (all call sites use the Workspace model).

### Document revisions removed

- `revision`, `prevRevision`, `revisionExpiresAt` (TTL soft delete), and the composite revision sort key are gone from the type, schema, model, NATS subjects, and web-ui plumbing. Document delete is now a hard delete of Main + Meta in one transaction.

### Docs & infra

- New `documentation/platform/DATA-STORAGE.md` (live-system framing) documenting scope-partitioned keying, the Main/Meta/Access-List triad, the one-transaction rule, and an explicit warning to avoid GSIs unless absolutely essential; docs index updated; stale table descriptions fixed in `INFRASTRUCTURE-OVERVIEW.md` and `WORKSPACE-EXPORT-IMPORT.md`.
- `infrastructure/pnpm-workspace.yaml`: allow the `protobufjs` build script — the `lixpi/pulumi-init` image rebuild was failing on it.

## Migration

Local data migrated with a one-shot backup → table recreation → reimport pass (counts verified per table). Backups retained under `services/api/temp-ai-responses/migration-backups/eliminate-gsis/`.

## Testing

- `docker compose ... lixpi-typescript-test-runner shared dynamodb-service` — 41 tests green
- `docker compose ... lixpi-typescript-test-runner api` — 582 tests / 65 files green
- `docker compose ... lixpi-typescript-test-runner web-ui` — 1391 tests / 103 files green