### PR TITLE
LIX-366 # Add Dockerized TypeScript CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,105 @@
+name: CI
+
+on:
+    pull_request:
+    push:
+        branches:
+            - main
+
+permissions:
+    contents: read
+
+concurrency:
+    group: ci-${{ github.event.pull_request.number || github.ref }}
+    cancel-in-progress: true
+
+env:
+    BUILDKIT_PROGRESS: plain
+    COMPOSE_ANSI: never
+
+jobs:
+    quality:
+        name: Formatting and linting / ${{ matrix.name }}
+        runs-on: ubuntu-latest
+        strategy:
+            fail-fast: false
+            matrix:
+                include:
+                    - name: runner-self-test
+                      command: self-test
+                    - name: web-ui
+                      command: web-ui validate
+                    - name: api
+                      command: api validate
+                    - name: nex
+                      command: nex validate
+                    - name: ai-model-registry
+                      command: ai-model-registry validate
+                    - name: quality-runner
+                      command: quality-runner validate
+                    - name: shared
+                      command: shared validate
+                    - name: docs-site
+                      command: docs-site validate
+                    - name: infrastructure
+                      command: infrastructure validate
+                    - name: random-useful-things
+                      command: random-useful-things validate
+        steps:
+            - name: Check out repository
+              uses: actions/checkout@v7
+
+            - name: Build TypeScript quality runner
+              run: docker compose -f docker-compose.typescript-quality-runner.yml --profile dev build lixpi-typescript-quality-runner
+
+            - name: Validate ${{ matrix.name }} formatting and lint rules
+              run: docker compose -f docker-compose.typescript-quality-runner.yml --profile dev run --rm --no-deps -T lixpi-typescript-quality-runner ${{ matrix.command }}
+
+    tests:
+        name: Tests / ${{ matrix.domain }}
+        runs-on: ubuntu-latest
+        strategy:
+            fail-fast: false
+            matrix:
+                domain:
+                    - api
+                    - web-ui
+                    - nex
+                    - shared
+                    - docs-site
+        env:
+            VITE_MOCK_AUTH: "true"
+            VITE_MOCK_AUTH0_DOMAIN: http://localhost:3000
+            VITE_API_URL: http://localhost:3001
+            VITE_AUTH0_LOGIN_URL: http://localhost:3000/authorize
+            VITE_AUTH0_DOMAIN: localhost
+            VITE_AUTH0_CLIENT_ID: ci
+            VITE_AUTH0_AUDIENCE: https://api.lixpi.test
+            VITE_AUTH0_REDIRECT_URI: http://localhost
+            VITE_STRIPE_PUBLIC_KEY: pk_test_ci
+            VITE_NATS_SERVER: ws://localhost:9222
+        steps:
+            - name: Check out repository
+              uses: actions/checkout@v7
+
+            - name: Build TypeScript test runner
+              run: docker compose -f docker-compose.typescript-test-runner.yml --profile dev build lixpi-typescript-test-runner
+
+            - name: Run ${{ matrix.domain }} tests
+              run: docker compose -f docker-compose.typescript-test-runner.yml --profile dev run --rm --no-deps -T lixpi-typescript-test-runner ${{ matrix.domain }}
+
+    gate:
+        name: Required CI gate
+        if: ${{ always() }}
+        needs:
+            - quality
+            - tests
+        runs-on: ubuntu-latest
+        steps:
+            - name: Require quality checks and tests
+              env:
+                  QUALITY_RESULT: ${{ needs.quality.result }}
+                  TEST_RESULT: ${{ needs.tests.result }}
+              run: |
+                  test "$QUALITY_RESULT" = "success"
+                  test "$TEST_RESULT" = "success"

--- a/documentation/testing/TypeScript/TESTING-GUIDE.md
+++ b/documentation/testing/TypeScript/TESTING-GUIDE.md
@@ -45,6 +45,12 @@ docker compose --profile dev --profile main run --rm --no-deps -T lixpi-typescri
 
 `shared` runs tests colocated inside whichever `packages/lixpi/*` package they belong to — the same colocation rule below applies there too, so a package's tests live right next to its source, not in a separate `tests/` directory. A `packages/lixpi/*` package only needs `vitest` as a devDependency and a `test:run` script once it actually has tests to run.
 
+## GitHub Actions
+
+The `CI` workflow runs `api`, `web-ui`, `nex`, `shared`, and `docs-site` as independent matrix jobs. Each job builds and invokes `lixpi-typescript-test-runner` through `docker-compose.typescript-test-runner.yml`; GitHub's host never installs pnpm, service dependencies, or Vitest.
+
+CI sets non-secret local placeholder values for the Vite variables required by the test-runner Compose service and still uses `--no-deps`, so no application, NATS, auth, or database service starts. Pointing Compose at the one-shot runner file preserves the local image, mounts, dispatcher, and domain boundary without requiring a developer `.env` file or parsing the root application graph. The test matrix and formatting-and-linting matrix feed one stable `Required CI gate` status for branch rules.
+
 Tests use **Vitest**. Globals are enabled, so you can use `describe`, `it`, `expect`, `vi` etc. without importing them, but we **do import them explicitly** for clarity.
 
 ```typescript

--- a/documentation/testing/TypeScript/TYPESCRIPT-QUALITY.md
+++ b/documentation/testing/TypeScript/TYPESCRIPT-QUALITY.md
@@ -20,35 +20,35 @@ docker compose --profile dev --profile main run --rm --no-deps -T --workdir /usr
 The quality runner follows the TypeScript test runner's domain shape. Run a service independently:
 
 ```bash
-docker compose --profile dev --profile main run --rm --no-deps -T lixpi-typescript-quality-runner web-ui check
-docker compose --profile dev --profile main run --rm --no-deps -T lixpi-typescript-quality-runner api check
-docker compose --profile dev --profile main run --rm --no-deps -T lixpi-typescript-quality-runner nex check
-docker compose --profile dev --profile main run --rm --no-deps -T lixpi-typescript-quality-runner ai-model-registry check
-docker compose --profile dev --profile main run --rm --no-deps -T lixpi-typescript-quality-runner quality-runner check
+docker compose --profile dev --profile main run --rm --no-deps -T lixpi-typescript-quality-runner web-ui validate
+docker compose --profile dev --profile main run --rm --no-deps -T lixpi-typescript-quality-runner api validate
+docker compose --profile dev --profile main run --rm --no-deps -T lixpi-typescript-quality-runner nex validate
+docker compose --profile dev --profile main run --rm --no-deps -T lixpi-typescript-quality-runner ai-model-registry validate
+docker compose --profile dev --profile main run --rm --no-deps -T lixpi-typescript-quality-runner quality-runner validate
 ```
 
 Run all shared packages or select one package by its directory name:
 
 ```bash
-docker compose --profile dev --profile main run --rm --no-deps -T lixpi-typescript-quality-runner shared check
-docker compose --profile dev --profile main run --rm --no-deps -T lixpi-typescript-quality-runner shared canvas-engine check
+docker compose --profile dev --profile main run --rm --no-deps -T lixpi-typescript-quality-runner shared validate
+docker compose --profile dev --profile main run --rm --no-deps -T lixpi-typescript-quality-runner shared canvas-engine validate
 docker compose --profile dev --profile main run --rm --no-deps -T lixpi-typescript-quality-runner shared canvas-components format
 ```
 
 The runner also exposes `docs-site`, `infrastructure`, `random-useful-things`, and `quality-runner` domains. TypeScript rules apply to every TypeScript file, while Sass and CSS rules apply to every first-party stylesheet. Use `all` when a repository-wide change needs every configured domain:
 
 ```bash
-docker compose --profile dev --profile main run --rm --no-deps -T lixpi-typescript-quality-runner all check
+docker compose --profile dev --profile main run --rm --no-deps -T lixpi-typescript-quality-runner all validate
 ```
 
-The action is optional and defaults to `check`.
+The action is optional and defaults to `validate`.
 
 | Action | Behavior |
 |--------|----------|
-| `check` | Runs `dprint check`, Oxlint, the named-import layout check, and Stylelint. It does not modify source. |
+| `validate` | Validates dprint formatting, Oxlint rules, named-import layout, and Stylelint rules. It does not modify source. |
 | `fix` | Runs `dprint fmt`, applies Oxlint's safe fixes, fixes named-import layout, and applies Stylelint's fixes. |
 | `format` | Runs `dprint fmt` and fixes named-import layout. |
-| `format-check` | Runs `dprint check` and the named-import layout check. |
+| `validate-formatting` | Validates dprint formatting and named-import layout. It does not modify source. |
 | `lint` | Runs Oxlint, the named-import layout check, and Stylelint. |
 | `lint-fix` | Applies Oxlint's and Stylelint's safe fixes and fixes named-import layout. |
 
@@ -122,6 +122,12 @@ dprint uses the `typescript-quality-runner-dprint-cache` volume for its compiled
 The repository configuration lives in [`dprint.json`](../../../dprint.json), [`.oxlintrc.json`](../../../.oxlintrc.json), and [`stylelint.config.mjs`](../../../stylelint.config.mjs). The package and committed lockfile under [`services/typescript-quality-runner`](../../../services/typescript-quality-runner/) pin the toolchain. There is no TypeScript build step and the tools do not emit JavaScript.
 
 Oxlint starts from an explicit rule baseline so adopting the runner does not silently turn unrelated existing findings into repository-wide failures. The quality runner rejects JSX source files, React imports, `debugger`, top-level `import type`, file imports without their TypeScript extension, duplicate module imports, CommonJS imports, `interface` declarations outside ambient `.d.ts` files, legacy own-property checks, JSON serialization used as a deep-clone substitute, restricted HTTP client packages, and restricted raw DOM construction in web-ui implementation files. Add broader rules deliberately and clean their existing findings in the same change.
+
+## GitHub Actions
+
+The `CI` workflow runs the quality-runner self-test and every configured quality domain as independent matrix jobs. Each job builds and invokes `lixpi-typescript-quality-runner` through `docker-compose.typescript-quality-runner.yml`, so dprint, Oxlint, Stylelint, and the repository validation scripts never run on the GitHub host.
+
+CI points Compose at the one-shot runner file directly. This keeps the same image, bind mounts, dispatcher, and domain commands used locally without parsing the unrelated application and deployment services from the root Compose graph. The matrix feeds one stable `Required CI gate` status after every quality and test job passes.
 
 ## Future Oxlint Stylistic Plugin Review
 

--- a/packages/lixpi/ui-kit/src/components/helpTooltip/help-tooltip.scss.test.ts
+++ b/packages/lixpi/ui-kit/src/components/helpTooltip/help-tooltip.scss.test.ts
@@ -38,10 +38,10 @@ describe('help-tooltip.scss', () => {
 
     it('uses a shared, placement-aware arrow that inherits the tooltip surface color', () => {
         expectSourceToContain(scss, '--help-tooltip-arrow-size: 6px;')
-        expectSourceToContain(scss, ".help-tooltip-content[data-placement='top']::before")
-        expectSourceToContain(scss, ".help-tooltip-content[data-placement='bottom']::before")
-        expectSourceToContain(scss, ".help-tooltip-content[data-placement='left']::before")
-        expectSourceToContain(scss, ".help-tooltip-content[data-placement='right']::before")
+        expectSourceToContain(scss, '.help-tooltip-content[data-placement="top"]::before')
+        expectSourceToContain(scss, '.help-tooltip-content[data-placement="bottom"]::before')
+        expectSourceToContain(scss, '.help-tooltip-content[data-placement="left"]::before')
+        expectSourceToContain(scss, '.help-tooltip-content[data-placement="right"]::before')
         expectSourceToContain(scss, 'var(--help-tooltip-arrow-surface-color)')
     })
 

--- a/services/typescript-quality-runner/run-quality.sh
+++ b/services/typescript-quality-runner/run-quality.sh
@@ -14,7 +14,7 @@ oxlint_config="$repository_dir/.oxlintrc.json"
 
 is_action() {
     case "$1" in
-        check|fix|lint|lint-fix|format|format-check) return 0 ;;
+        validate|fix|lint|lint-fix|format|validate-formatting) return 0 ;;
         *) return 1 ;;
     esac
 }
@@ -24,7 +24,7 @@ run_action() {
     shift
 
     case "$action" in
-        check)
+        validate)
             "$dprint_bin" check --config "$dprint_config" "$@"
             "$oxlint_bin" --config "$oxlint_config" --deny-warnings "$@"
             node "$import_order_checker" check "$@"
@@ -50,7 +50,7 @@ run_action() {
             "$dprint_bin" fmt --config "$dprint_config" "$@"
             node "$import_order_checker" fix "$@"
             ;;
-        format-check)
+        validate-formatting)
             "$dprint_bin" check --config "$dprint_config" "$@"
             node "$import_order_checker" check "$@"
             ;;
@@ -63,7 +63,7 @@ run_action() {
 
 run_shared() {
     package_filter=""
-    action="check"
+    action="validate"
 
     if [ "$#" -gt 0 ] && is_action "$1"; then
         action="$1"
@@ -115,7 +115,7 @@ run_shared() {
 
 run_domain() {
     domain="$1"
-    action="${2:-check}"
+    action="${2:-validate}"
 
     case "$domain" in
         web-ui)
@@ -150,7 +150,7 @@ run_domain() {
 }
 
 run_all() {
-    action="${1:-check}"
+    action="${1:-validate}"
     run_action "$action" \
         services/web-ui/src \
         services/web-ui/vite.config.ts \
@@ -187,7 +187,7 @@ cd "$repository_dir"
 
 domain="${1:-}"
 if [ -z "$domain" ]; then
-    echo "Usage: run-quality.sh {web-ui|api|nex|ai-model-registry|docs-site|infrastructure|random-useful-things|quality-runner|shared|all|self-test} [package] [check|fix|lint|lint-fix|format|format-check]" >&2
+    echo "Usage: run-quality.sh {web-ui|api|nex|ai-model-registry|docs-site|infrastructure|random-useful-things|quality-runner|shared|all|self-test} [package] [validate|fix|lint|lint-fix|format|validate-formatting]" >&2
     exit 1
 fi
 shift
@@ -197,13 +197,13 @@ case "$domain" in
         run_shared "$@"
         ;;
     all)
-        run_all "${1:-check}"
+        run_all "${1:-validate}"
         ;;
     self-test)
         sh "$runner_dir/test-quality.sh"
         ;;
     web-ui|api|nex|ai-model-registry|docs-site|infrastructure|random-useful-things|quality-runner)
-        run_domain "$domain" "${1:-check}"
+        run_domain "$domain" "${1:-validate}"
         ;;
     *)
         echo "Unknown domain: $domain" >&2


### PR DESCRIPTION
## Changes

- Add a GitHub Actions workflow that runs each TypeScript quality and test domain through its existing one-shot Docker Compose runner.
- Keep service and shared-package executions separate, matching the documented local commands.
- Publish one stable `Required CI gate` status after every matrix job succeeds.
- Rename the quality runner's non-mutating actions to `validate` and `validate-formatting`.
- Align the help-tooltip source assertion with dprint's formatted selector quotes.

This PR is stacked on #365 because that PR adds the quality runner and lint configuration used by the workflow.

Closes #366
