### PR TITLE
LIX-366 # Fix html template formatting and console autofix in the quality runner

### DIFF
--- a/services/typescript-quality-runner/lixpi-oxlint-plugin.ts
+++ b/services/typescript-quality-runner/lixpi-oxlint-plugin.ts
@@ -97,8 +97,28 @@ const noUnusedImports = defineRule({
     },
     create(context) {
         const { sourceCode } = context
+        // `no-native-console-logging` rewrites `console.log(...)` onto the debug-tools
+        // specifier of the same name in this very fix round. Removing that specifier as
+        // unused in the same round leaves the rewritten call with nothing to bind to, so
+        // a specifier the console rule is about to claim counts as used.
+        const pendingConsoleImportNames = new Set()
 
         return {
+            CallExpression(node) {
+                if (
+                    node.callee.type !== 'MemberExpression'
+                    || node.callee.computed
+                    || node.callee.object.type !== 'Identifier'
+                    || node.callee.object.name !== 'console'
+                    || node.callee.property.type !== 'Identifier'
+                    || !debugLoggingMethods.has(node.callee.property.name)
+                )
+                    return
+
+                pendingConsoleImportNames.add(
+                    debugLoggingMethods.get(node.callee.property.name).importedName,
+                )
+            },
             'Program:exit'() {
                 const commentReferencedNames = getCommentReferencedIdentifierNames(sourceCode)
                 const unusedSpecifiersByDeclaration = new Map()
@@ -122,6 +142,14 @@ const noUnusedImports = defineRule({
                         if (
                             !specifier
                             || declaration?.type !== 'ImportDeclaration'
+                        )
+                            continue
+
+                        if (
+                            declaration.source.value === '@lixpi/debug-tools'
+                            && specifier.type === 'ImportSpecifier'
+                            && specifier.imported.type === 'Identifier'
+                            && pendingConsoleImportNames.has(specifier.imported.name)
                         )
                             continue
 

--- a/services/typescript-quality-runner/oxfmt.json
+++ b/services/typescript-quality-runner/oxfmt.json
@@ -1,7 +1,7 @@
 {
     "$schema": "./node_modules/oxfmt/configuration_schema.json",
     "arrowParens": "avoid",
-    "embeddedLanguageFormatting": "auto",
+    "embeddedLanguageFormatting": "off",
     "endOfLine": "lf",
     "ignorePatterns": [
         "**/*.css",

--- a/services/typescript-quality-runner/test-quality.sh
+++ b/services/typescript-quality-runner/test-quality.sh
@@ -4,12 +4,15 @@ set -eu
 
 repository_dir="/usr/src/repository"
 tool_dir="/usr/src/quality-runner"
-runner_dir="$repository_dir/services/typescript-quality-runner"
+runner_dir="$tool_dir"
 dprint_bin="$tool_dir/node_modules/.bin/dprint"
 oxlint_bin="$tool_dir/node_modules/.bin/oxlint"
 import_order_checker="$runner_dir/import-specifier-order.ts"
+typescript_format_runner="$runner_dir/typescript-format-runner.ts"
 stylelint_runner="$tool_dir/stylelint-runner.ts"
-dprint_config="$repository_dir/dprint.json"
+# dprint now formats stylesheets only. TypeScript goes through the oxfmt-backed
+# typescript-format-runner, so a .ts path handed to dprint matches no plugin at all.
+dprint_config="$tool_dir/dprint.json"
 oxlint_config="$repository_dir/.oxlintrc.json"
 fixture_dir="$runner_dir/fixtures"
 temporary_dir=$(mktemp -d)
@@ -20,21 +23,21 @@ cleanup() {
 trap cleanup EXIT
 
 cp "$fixture_dir/import-layout-input.txt" "$temporary_dir/import-layout.ts"
-if "$dprint_bin" check --config "$dprint_config" "$temporary_dir/import-layout.ts" >/dev/null 2>&1 \
+if node "$typescript_format_runner" check "$temporary_dir/import-layout.ts" >/dev/null 2>&1 \
     && node "$import_order_checker" check "$temporary_dir/import-layout.ts" >/dev/null 2>&1; then
     echo "Expected the composite formatter to reject the invalid import fixture" >&2
     exit 1
 fi
 
-"$dprint_bin" fmt --config "$dprint_config" "$temporary_dir/import-layout.ts" >/dev/null
+node "$typescript_format_runner" fix "$temporary_dir/import-layout.ts" >/dev/null
 node "$import_order_checker" fix "$temporary_dir/import-layout.ts" >/dev/null
 if ! cmp -s "$fixture_dir/import-layout-expected.txt" "$temporary_dir/import-layout.ts"; then
-    echo "dprint did not produce the expected multiline import layout" >&2
+    echo "The TypeScript formatter did not produce the expected multiline import layout" >&2
     diff -u "$fixture_dir/import-layout-expected.txt" "$temporary_dir/import-layout.ts" >&2 || true
     exit 1
 fi
 
-"$dprint_bin" check --config "$dprint_config" "$temporary_dir/import-layout.ts" >/dev/null
+node "$typescript_format_runner" check "$temporary_dir/import-layout.ts" >/dev/null
 node "$import_order_checker" check "$temporary_dir/import-layout.ts" >/dev/null
 
 cp "$fixture_dir/lint-invalid.txt" "$temporary_dir/lint-invalid.ts"

--- a/services/typescript-quality-runner/typescript-format-runner.ts
+++ b/services/typescript-quality-runner/typescript-format-runner.ts
@@ -148,6 +148,11 @@ type HtmlTemplateContent = {
     start: number
 }
 
+type HtmlTemplateQuasi = {
+    span: LayoutSpan
+    templateStart: number
+}
+
 type CallChainSegment = {
     boundaryEnd: number
     boundaryStart: number
@@ -1273,13 +1278,13 @@ const isHtmlTemplateTag = (tag: AstNode | undefined): boolean => tag?.type === '
 const collectHtmlTemplateQuasis = (
     file: string,
     source: string,
-): LayoutSpan[] => {
+): HtmlTemplateQuasi[] => {
     const parseResult = parseTypeScript(file, source)
 
     if (parseResult.errors.length > 0)
         throw new Error(`Oxc parser could not parse ${file}: ${JSON.stringify(parseResult.errors[0])}`)
 
-    const layouts: LayoutSpan[] = []
+    const layouts: HtmlTemplateQuasi[] = []
     const visit = (node: AstNode): void => {
         const tag = node.tag as AstNode | undefined
         const template = node.quasi as AstNode | undefined
@@ -1290,20 +1295,27 @@ const collectHtmlTemplateQuasis = (
             && template?.type === 'TemplateLiteral'
             && Array.isArray(template.quasis)
         ) {
+            const templateRange = getNodeRange(template)
+
             for (const quasi of template.quasis) {
                 if (!isAstNode(quasi))
                     continue
 
                 const quasiRange = getNodeRange(quasi)
 
-                if (quasiRange)
-                    layouts.push(
-                        getLayoutSpan(
+                if (
+                    quasiRange
+                    && templateRange
+                ) {
+                    layouts.push({
+                        span: getLayoutSpan(
                             quasiRange[0],
                             quasiRange[1],
                             source,
                         ),
-                    )
+                        templateStart: templateRange[0],
+                    })
+                }
             }
         }
 
@@ -1325,15 +1337,10 @@ const collectHtmlTemplateQuasis = (
 }
 
 const reindentHtmlTemplate = (
-    source: string,
-    sourceLayout: LayoutSpan,
-    target: string,
-    targetLayout: LayoutSpan,
+    text: string,
+    indentationDifference: number,
 ): string => {
-    const sourceIndentation = getLineIndentation(source, sourceLayout.start)
-    const targetIndentation = getLineIndentation(target, targetLayout.start)
-    const indentationDifference = targetIndentation.length - sourceIndentation.length
-    const lines = sourceLayout.text.split('\n')
+    const lines = text.split('\n')
 
     for (let index = 1; index < lines.length; index++) {
         const line = lines[index]!
@@ -1360,16 +1367,21 @@ const applyHtmlTemplateFormatting = (
     if (formattedLayouts.length !== htmlLayouts.length)
         throw new Error(`Oxfmt changed the html template syntax shape in ${file}`)
 
+    // Every quasi of one template shares a single indentation delta, measured at the
+    // template's opening backtick. Measuring per quasi instead reads the indentation of
+    // whatever interpolation that quasi resumes after, which differs between the two
+    // oxfmt passes and shifts the closing tags further right on every run.
     const replacements = formattedLayouts.map(
-        (target, index) => ({
-            ...target,
-            text: reindentHtmlTemplate(
-                htmlFormatted,
-                htmlLayouts[index]!,
-                formatted,
-                target,
-            ),
-        }),
+        (target, index) => {
+            const htmlQuasi = htmlLayouts[index]!
+            const indentationDifference = getLineIndentation(formatted, target.templateStart).length
+                - getLineIndentation(htmlFormatted, htmlQuasi.templateStart).length
+
+            return {
+                ...target.span,
+                text: reindentHtmlTemplate(htmlQuasi.span.text, indentationDifference),
+            }
+        },
     )
     let output = formatted
 


### PR DESCRIPTION
Four fixes to the TypeScript quality runner. All of them are causes of CI failures on #374, and each one is a bug in the tooling rather than in the code it rewrote.

**`oxfmt.json` — `embeddedLanguageFormatting` is now `off`.** It was `auto`, so oxfmt formatted `html` tagged templates using Prettier's HTML whitespace rules. Our `html` tag is `htm`, which drops a whitespace run only when it contains a newline. When oxfmt collapsed a template onto one line it joined two adjacent interpolations with a literal space, and `htm` turns that space into a real text node in the DOM. On #374 that silently changed rendered output in `branch-marker-content.ts`, `workspace-canvas-chrome.ts`, `canvasNodeFooter.ts`, `progressTimeline.ts` and `modelConfigurationRow.ts`.

**`typescript-format-runner.ts` — one indentation delta per template.** `reindentHtmlTemplate` measured the delta separately for every quasi. A quasi that resumes after a `${...}` starts mid-line, so it read the indentation of whatever the interpolation ended on, and the two oxfmt passes disagree about that. The formatter was therefore not idempotent: `context-preview.ts:403` gained four spaces on every run, which is what failed `Formatting and linting / shared`. The delta is now measured once per template at its opening backtick.

**`lixpi-oxlint-plugin.ts` — `no-unused-imports` yields to `no-native-console-logging`.** The console rule rewrites `console.log(...)` onto an existing debug-tools specifier of the same name. In the same fix round, `no-unused-imports` saw that specifier as unreferenced and removed it. On #374 that left three live `log(...)` calls in `services/api/src/services/subscription-service.ts` with nothing to bind to, so those methods would throw `ReferenceError`. The unused-import rule now keeps a debug-tools specifier the console rule is about to claim.

**`test-quality.sh` — the import fixture goes through the format runner.** dprint became stylesheet-only when the root `dprint.json` moved under the runner, so handing it a `.ts` path matched no plugin and it exited 14 under `set -e`. That was the whole `runner-self-test` failure.

## Verification

`self-test` passes. On a reduced fixture the template now survives three format passes unchanged with a clean `check`, where before it drifted right on every pass.

`api validate` reports 159 formatting violations both with and without this change, so the existing red `Formatting and linting` jobs are a property of `main` not having been reformatted yet, not something this PR causes. They clear when the repo-wide reformat lands.

Relates to #366