### PR TITLE
LIX-366 # Break brace-less loop bodies onto their own line

### DIFF
--- a/packages/lixpi/canvas-components-lixpi-specific/src/frontend/context/workspace-context-trays.ts
+++ b/packages/lixpi/canvas-components-lixpi-specific/src/frontend/context/workspace-context-trays.ts
@@ -163,7 +163,8 @@ export class WorkspaceContextTrays {
         this.destroyed = true
         const lifetime = new Lifetime()
 
-        for (const tray of this.entries.values()) lifetime.own(() => tray.destroy())
+        for (const tray of this.entries.values())
+            lifetime.own(() => tray.destroy())
 
         this.entries.clear()
         lifetime.destroy()

--- a/packages/lixpi/canvas-components-lixpi-specific/src/frontend/library/artifact-library-panel.ts
+++ b/packages/lixpi/canvas-components-lixpi-specific/src/frontend/library/artifact-library-panel.ts
@@ -230,9 +230,10 @@ class ArtifactLibraryPanel implements ArtifactLibraryPanelInstance {
             else {
                 const list = this.html`<div className="capability-library-section-items"></div>` as HTMLElement
 
-                for (const entry of this.entries) list.appendChild(
-                    this.createRow(entry),
-                )
+                for (const entry of this.entries)
+                    list.appendChild(
+                        this.createRow(entry),
+                    )
 
                 this.browserEl.appendChild(list)
             }

--- a/packages/lixpi/canvas-components-lixpi-specific/src/frontend/library/capability-library-panel.ts
+++ b/packages/lixpi/canvas-components-lixpi-specific/src/frontend/library/capability-library-panel.ts
@@ -151,9 +151,10 @@ class CapabilityLibraryPanel implements CapabilityLibraryPanelInstance {
         else {
             const itemsElement = this.html`<div className="capability-library-section-items"></div>` as HTMLElement
 
-            for (const item of this.items) itemsElement.appendChild(
-                this.buildRow(item),
-            )
+            for (const item of this.items)
+                itemsElement.appendChild(
+                    this.buildRow(item),
+                )
 
             this.browserElement.appendChild(itemsElement)
         }

--- a/packages/lixpi/canvas-components-lixpi-specific/src/frontend/library/media-library-panel.ts
+++ b/packages/lixpi/canvas-components-lixpi-specific/src/frontend/library/media-library-panel.ts
@@ -250,9 +250,10 @@ class MediaLibraryPanel implements MediaLibraryPanelInstance {
             else {
                 const itemsEl = this.html`<div className="capability-library-section-items"></div>` as HTMLElement
 
-                for (const asset of this.allAssets) itemsEl.appendChild(
-                    this.buildAssetRow(asset),
-                )
+                for (const asset of this.allAssets)
+                    itemsEl.appendChild(
+                        this.buildAssetRow(asset),
+                    )
 
                 this.browserEl.appendChild(itemsEl)
             }

--- a/packages/lixpi/canvas-components-lixpi-specific/src/frontend/media/workspace-generation-visuals.ts
+++ b/packages/lixpi/canvas-components-lixpi-specific/src/frontend/media/workspace-generation-visuals.ts
@@ -154,8 +154,9 @@ export class WorkspaceGenerationVisuals {
         }
 
         for (const references of this.references.values()) {
-            for (const nodeId of references) if (!targets.has(nodeId))
-                targets.set(nodeId, { direction: 'counterclockwise' })
+            for (const nodeId of references)
+                if (!targets.has(nodeId))
+                    targets.set(nodeId, { direction: 'counterclockwise' })
         }
 
         this.ports.setTargets(targets)
@@ -240,15 +241,17 @@ export class WorkspaceGenerationVisuals {
             return ids
 
         for (const tracker of [this.ports.images, this.ports.videos]) {
-            for (const node of tracker.values()) if (
-                !node.hasReceivedFrame
-                && !this.hasTerminalProgress(node.nodeId)
-            )
-                ids.add(node.nodeId)
+            for (const node of tracker.values())
+                if (
+                    !node.hasReceivedFrame
+                    && !this.hasTerminalProgress(node.nodeId)
+                )
+                    ids.add(node.nodeId)
         }
 
-        for (const node of this.ports.getState()?.nodes ?? []) if (this.isWaitingForFrame(node))
-            ids.add(node.nodeId)
+        for (const node of this.ports.getState()?.nodes ?? [])
+            if (this.isWaitingForFrame(node))
+                ids.add(node.nodeId)
 
         return ids
     }
@@ -295,8 +298,9 @@ export class WorkspaceGenerationVisuals {
             return false
 
         for (const tracker of [this.ports.images, this.ports.videos]) {
-            for (const pending of tracker.values()) if (pending.nodeId === nodeId)
-                return !pending.hasReceivedFrame
+            for (const pending of tracker.values())
+                if (pending.nodeId === nodeId)
+                    return !pending.hasReceivedFrame
         }
 
         const node = this.ports.getState()?.nodes.find(candidate => candidate.nodeId === nodeId)

--- a/packages/lixpi/canvas-components-lixpi-specific/src/frontend/media/workspace-media-sources.ts
+++ b/packages/lixpi/canvas-components-lixpi-specific/src/frontend/media/workspace-media-sources.ts
@@ -108,7 +108,8 @@ export class WorkspaceMediaSources implements MediaSourceResolver {
     }
 
     retry(assetIds: ReadonlySet<string>): void {
-        for (const assetId of assetIds) this.retries.set(assetId, (this.retries.get(assetId) ?? 0) + 1)
+        for (const assetId of assetIds)
+            this.retries.set(assetId, (this.retries.get(assetId) ?? 0) + 1)
     }
 
     clear(): void {

--- a/packages/lixpi/canvas-components-lixpi-specific/src/frontend/media/workspace-output-chrome.ts
+++ b/packages/lixpi/canvas-components-lixpi-specific/src/frontend/media/workspace-output-chrome.ts
@@ -206,13 +206,15 @@ export class WorkspaceOutputChrome {
         try {
             this.ports.video.sync(videos)
 
-            for (const node of pending) this.mountPendingIcon(node)
+            for (const node of pending)
+                this.mountPendingIcon(node)
 
-            for (const node of [...media, ...artifacts]) this.mountFooter(
-                node,
-                state,
-                pendingIds.has(node.nodeId),
-            )
+            for (const node of [...media, ...artifacts])
+                this.mountFooter(
+                    node,
+                    state,
+                    pendingIds.has(node.nodeId),
+                )
 
             this.layout(
                 this.ports.getViewport(),

--- a/packages/lixpi/canvas-components-lixpi-specific/src/frontend/media/workspace-video-chrome.ts
+++ b/packages/lixpi/canvas-components-lixpi-specific/src/frontend/media/workspace-video-chrome.ts
@@ -157,7 +157,8 @@ export class WorkspaceVideoChrome {
         this.entries.clear()
         const cleanup = new Lifetime()
 
-        for (const entry of entries) cleanup.own(() => entry.destroy())
+        for (const entry of entries)
+            cleanup.own(() => entry.destroy())
 
         cleanup.destroy()
     }

--- a/packages/lixpi/canvas-components-lixpi-specific/src/frontend/nodes/branch-marker-actions.ts
+++ b/packages/lixpi/canvas-components-lixpi-specific/src/frontend/nodes/branch-marker-actions.ts
@@ -74,7 +74,8 @@ export class BranchMarkerActions {
         ` as HTMLButtonElement
         this.lifetime.own(() => button.remove())
 
-        for (const type of ['pointerdown', 'pointerup', 'mousedown', 'mouseup']) this.listen(button, type)
+        for (const type of ['pointerdown', 'pointerup', 'mousedown', 'mouseup'])
+            this.listen(button, type)
 
         this.listen(
             button,

--- a/packages/lixpi/canvas-components-lixpi-specific/src/frontend/nodes/document-node.ts
+++ b/packages/lixpi/canvas-components-lixpi-specific/src/frontend/nodes/document-node.ts
@@ -82,9 +82,10 @@ export class WorkspaceDocumentNodes {
             documents.map(document => [document.documentId, document]),
         )
 
-        for (const view of this.views.values()) view.setDocument(
-            byId.get(view.assetId),
-        )
+        for (const view of this.views.values())
+            view.setDocument(
+                byId.get(view.assetId),
+            )
     }
 
     destroy(): void {
@@ -93,7 +94,8 @@ export class WorkspaceDocumentNodes {
 
         this.destroyed = true
 
-        for (const view of this.views.values()) view.destroy()
+        for (const view of this.views.values())
+            view.destroy()
 
         this.views.clear()
     }

--- a/packages/lixpi/canvas-components-lixpi-specific/src/frontend/nodes/workspace-node-shells.ts
+++ b/packages/lixpi/canvas-components-lixpi-specific/src/frontend/nodes/workspace-node-shells.ts
@@ -286,7 +286,8 @@ export class WorkspaceNodeShells {
     }
 
     setZoom(zoom: number): void {
-        for (const { shell } of this.entries.values()) shell.setZoom(zoom)
+        for (const { shell } of this.entries.values())
+            shell.setZoom(zoom)
     }
 
     replace(
@@ -325,7 +326,8 @@ export class WorkspaceNodeShells {
     clear(): void {
         for (const id of Array.from(
             this.entries.keys(),
-        )) this.remove(id)
+        ))
+            this.remove(id)
     }
 
     destroy(): void {

--- a/packages/lixpi/canvas-components-lixpi-specific/src/frontend/workspace/canvas-conversation-editors.ts
+++ b/packages/lixpi/canvas-components-lixpi-specific/src/frontend/workspace/canvas-conversation-editors.ts
@@ -147,7 +147,8 @@ export class CanvasConversationEditors<Entry> {
         this.slots.clear()
         const cleanup = new Lifetime()
 
-        for (const slot of slots) cleanup.own(() => slot.lifetime.destroy())
+        for (const slot of slots)
+            cleanup.own(() => slot.lifetime.destroy())
 
         cleanup.destroy()
     }

--- a/packages/lixpi/canvas-components-lixpi-specific/src/frontend/workspace/workspace-branch-marker-generation.ts
+++ b/packages/lixpi/canvas-components-lixpi-specific/src/frontend/workspace/workspace-branch-marker-generation.ts
@@ -245,7 +245,8 @@ export class WorkspaceBranchMarkerGeneration {
 
         this.ports.pruneTrackers(nodeIds)
 
-        for (const nodeId of nodeIds) this.ports.removeSelection(nodeId)
+        for (const nodeId of nodeIds)
+            this.ports.removeSelection(nodeId)
 
         this.ports.commit({
             ...state,

--- a/packages/lixpi/canvas-components-lixpi-specific/src/frontend/workspace/workspace-branch-marker-presentation.ts
+++ b/packages/lixpi/canvas-components-lixpi-specific/src/frontend/workspace/workspace-branch-marker-presentation.ts
@@ -133,7 +133,8 @@ export class WorkspaceBranchMarkerPresentation {
     }
 
     updateZoom(zoomScale: number): void {
-        for (const controls of this.actions.values()) controls.setZoomScale(zoomScale)
+        for (const controls of this.actions.values())
+            controls.setZoomScale(zoomScale)
     }
 
     destroyNode(nodeId: string): void {

--- a/packages/lixpi/canvas-components-lixpi-specific/src/frontend/workspace/workspace-branch-marker-projection.ts
+++ b/packages/lixpi/canvas-components-lixpi-specific/src/frontend/workspace/workspace-branch-marker-projection.ts
@@ -198,7 +198,8 @@ export class WorkspaceBranchMarkerProjection {
     }
 
     refreshThreads = (threadIds: Iterable<string>): void => {
-        for (const threadId of threadIds) this.refresh(threadId)
+        for (const threadId of threadIds)
+            this.refresh(threadId)
     }
 
     private getContentDimensions(

--- a/packages/lixpi/canvas-components-lixpi-specific/src/frontend/workspace/workspace-canvas-chrome.ts
+++ b/packages/lixpi/canvas-components-lixpi-specific/src/frontend/workspace/workspace-canvas-chrome.ts
@@ -216,7 +216,8 @@ export class WorkspaceCanvasChrome {
             ),
         }
 
-        for (const [name, value] of Object.entries(properties)) this.element.style.setProperty(name, value)
+        for (const [name, value] of Object.entries(properties))
+            this.element.style.setProperty(name, value)
     }
 
     private async invoke(action: () => Promise<void>): Promise<void> {

--- a/packages/lixpi/canvas-components-lixpi-specific/src/frontend/workspace/workspace-canvas-cleanup.ts
+++ b/packages/lixpi/canvas-components-lixpi-specific/src/frontend/workspace/workspace-canvas-cleanup.ts
@@ -3,7 +3,8 @@ import { Lifetime } from '@lixpi/canvas-engine/frontend/runtime'
 export const destroyWorkspaceCanvasResources = (cleanups: Iterable<() => void>): void => {
     const lifetime = new Lifetime()
 
-    for (const cleanup of cleanups) lifetime.own(cleanup)
+    for (const cleanup of cleanups)
+        lifetime.own(cleanup)
 
     lifetime.destroy()
 }

--- a/packages/lixpi/canvas-components-lixpi-specific/src/frontend/workspace/workspace-canvas-surface.ts
+++ b/packages/lixpi/canvas-components-lixpi-specific/src/frontend/workspace/workspace-canvas-surface.ts
@@ -306,9 +306,10 @@ export class WorkspaceCanvasSurface {
             )
             this.reconcile()
 
-            for (const subscribe of ports.subscriptions) this.lifetime.own(
-                subscribe(this.reconcile),
-            )
+            for (const subscribe of ports.subscriptions)
+                this.lifetime.own(
+                    subscribe(this.reconcile),
+                )
         } catch (error) {
             try {
                 this.destroy()

--- a/packages/lixpi/canvas-components-lixpi-specific/src/frontend/workspace/workspace-canvas-theme.ts
+++ b/packages/lixpi/canvas-components-lixpi-specific/src/frontend/workspace/workspace-canvas-theme.ts
@@ -47,7 +47,8 @@ export const applyWorkspaceCanvasTheme = (
         '--workspace-branch-marker-response-line-height': `${markerText.responseLineHeight}`,
     }
 
-    for (const [name, value] of Object.entries(properties)) pane.style.setProperty(name, value)
+    for (const [name, value] of Object.entries(properties))
+        pane.style.setProperty(name, value)
 }
 
 export const getWorkspaceRightPanelCssProperties = (settings: WorkspaceCanvasSettings): Record<`--${string}`, string> => {

--- a/packages/lixpi/canvas-components-lixpi-specific/src/frontend/workspace/workspace-node-gestures.ts
+++ b/packages/lixpi/canvas-components-lixpi-specific/src/frontend/workspace/workspace-node-gestures.ts
@@ -380,7 +380,8 @@ export class WorkspaceNodeGestures {
         }
 
         const cleanup = this.ownGestureCleanup(scope, () => {
-            for (const entry of draggedNodeEntries.values()) entry.el.classList.remove('is-dragging')
+            for (const entry of draggedNodeEntries.values())
+                entry.el.classList.remove('is-dragging')
         })
         let dragVisualsActivated = false
         const activateDragVisuals = () => {

--- a/packages/lixpi/canvas-components-lixpi-specific/src/frontend/workspace/workspace-right-panel.ts
+++ b/packages/lixpi/canvas-components-lixpi-specific/src/frontend/workspace/workspace-right-panel.ts
@@ -235,7 +235,8 @@ export class WorkspaceRightPanel {
         }
 
         try {
-            for (const [name, value] of Object.entries(this.options.cssProperties)) panel.style.setProperty(name, value)
+            for (const [name, value] of Object.entries(this.options.cssProperties))
+                panel.style.setProperty(name, value)
 
             const switchElement = preservedSwitch ?? this.createModeSwitch(state.topLevelMode)
             panel.appendChild(switchElement)

--- a/packages/lixpi/canvas-components-lixpi-specific/src/shared/assets/workspace-assets.ts
+++ b/packages/lixpi/canvas-components-lixpi-specific/src/shared/assets/workspace-assets.ts
@@ -69,7 +69,8 @@ export const getWorkspaceCanvasAssetIds = (canvasState: CanvasState | undefined)
             assetIds.add(node.generatedBy.conversationAssetId)
     }
 
-    for (const assetId of getPersistedPanelConversationIds(canvasState.aiChatPanel)) assetIds.add(assetId)
+    for (const assetId of getPersistedPanelConversationIds(canvasState.aiChatPanel))
+        assetIds.add(assetId)
 
     if (canvasState.lastActiveConversationAssetId)
         assetIds.add(canvasState.lastActiveConversationAssetId)

--- a/packages/lixpi/canvas-components-lixpi-specific/src/shared/branch-tree-layout/branch-tree-layout.ts
+++ b/packages/lixpi/canvas-components-lixpi-specific/src/shared/branch-tree-layout/branch-tree-layout.ts
@@ -374,7 +374,8 @@ export const buildBranchTrees = (
     }
 
     for (const tree of treesByRoot.values()) {
-        for (const siblings of tree.childrenByParentId.values()) siblings.sort(compareSiblings)
+        for (const siblings of tree.childrenByParentId.values())
+            siblings.sort(compareSiblings)
     }
 
     return [...treesByRoot.values()]
@@ -385,7 +386,8 @@ const parentByChildOf = (tree: BranchTree): Map<string, string> => {
     const parentByChild = new Map<string, string>()
 
     for (const [parentId, children] of tree.childrenByParentId) {
-        for (const childId of children) parentByChild.set(childId, parentId)
+        for (const childId of children)
+            parentByChild.set(childId, parentId)
     }
 
     return parentByChild
@@ -793,11 +795,13 @@ export const applyBranchTreeLayout = (
             if (layoutMemberIds.has(id))
                 orderedLayoutMemberIds.push(id)
 
-            for (const childId of tree.childrenByParentId.get(id) ?? []) visitInSiblingOrder(childId)
+            for (const childId of tree.childrenByParentId.get(id) ?? [])
+                visitInSiblingOrder(childId)
         }
         visitInSiblingOrder(tree.rootId)
 
-        for (const id of tree.memberIds) visitInSiblingOrder(id)
+        for (const id of tree.memberIds)
+            visitInSiblingOrder(id)
 
         const layoutNodes: TreeLayoutNode[] = orderedLayoutMemberIds.map((id: string) => {
             const node = nodesById.get(id) as BranchTreeMemberNode
@@ -1096,7 +1100,8 @@ export const rebalanceBranchTreesAndResolve = (
     const memberToRoot = new Map<string, string>()
 
     for (const tree of trees) {
-        for (const id of tree.memberIds) memberToRoot.set(id, tree.rootId)
+        for (const id of tree.memberIds)
+            memberToRoot.set(id, tree.rootId)
     }
 
     const boxes: CollisionBox[] = []

--- a/packages/lixpi/canvas-components-lixpi-specific/src/shared/branch-tree-layout/generated-media-rebalance.ts
+++ b/packages/lixpi/canvas-components-lixpi-specific/src/shared/branch-tree-layout/generated-media-rebalance.ts
@@ -252,7 +252,8 @@ export const reflowStackedBranchMarkers = (options: ReflowStackedBranchMarkersOp
 
     const nodesById = getNodesById(options.allNodes)
 
-    for (const marker of options.markers) nodesById.set(marker.nodeId, marker)
+    for (const marker of options.markers)
+        nodesById.set(marker.nodeId, marker)
 
     for (const group of groups) {
         let y = getBranchMarkerStackAnchorTop(

--- a/packages/lixpi/canvas-components-lixpi-specific/src/shared/branch-tree-layout/marker-prompt-parts.ts
+++ b/packages/lixpi/canvas-components-lixpi-specific/src/shared/branch-tree-layout/marker-prompt-parts.ts
@@ -107,7 +107,8 @@ const collectRawPromptParts = (node: ProseMirrorJsonNode | undefined): BranchMar
             return
         }
 
-        for (const child of candidate.content ?? []) visit(child)
+        for (const child of candidate.content ?? [])
+            visit(child)
     }
     visit(node)
 

--- a/packages/lixpi/canvas-components-lixpi-specific/src/shared/composer/canvas-conversation-content.ts
+++ b/packages/lixpi/canvas-components-lixpi-specific/src/shared/composer/canvas-conversation-content.ts
@@ -131,7 +131,8 @@ export const extractPromptTextFromContentJSON = (contentJSON: any): string => {
             return
 
         if (Array.isArray(node)) {
-            for (const child of node) visit(child)
+            for (const child of node)
+                visit(child)
 
             return
         }
@@ -164,7 +165,8 @@ export const extractPromptTextFromContentJSON = (contentJSON: any): string => {
             chunks.push('\n')
 
         if (Array.isArray(node.content)) {
-            for (const child of node.content) visit(child)
+            for (const child of node.content)
+                visit(child)
 
             if (node.type === 'paragraph')
                 chunks.push('\n')

--- a/packages/lixpi/canvas-components-lixpi-specific/src/shared/generation/operation-recovery.ts
+++ b/packages/lixpi/canvas-components-lixpi-specific/src/shared/generation/operation-recovery.ts
@@ -592,7 +592,8 @@ const applyOperationPatches = (
             progressState: projection.progressState,
         })
 
-        for (const nodeId of mediaProjection.updatedNodeIds) updatedNodeIds.add(nodeId)
+        for (const nodeId of mediaProjection.updatedNodeIds)
+            updatedNodeIds.add(nodeId)
 
         nodes = mediaProjection.nodes
     }
@@ -802,7 +803,8 @@ export const applyMediaGenerationRequestToOperationNodes = (
         })
         nodes = mediaProjection.nodes
 
-        for (const nodeId of mediaProjection.updatedNodeIds) updatedNodeIds.add(nodeId)
+        for (const nodeId of mediaProjection.updatedNodeIds)
+            updatedNodeIds.add(nodeId)
     }
 
     let resultState = {
@@ -844,7 +846,8 @@ export const applyMediaGenerationRequestToOperationNodes = (
             updatedNodeIds.delete(nodeId)
         }
 
-        for (const nodeId of replacement.updatedNodeIds) updatedNodeIds.add(nodeId)
+        for (const nodeId of replacement.updatedNodeIds)
+            updatedNodeIds.add(nodeId)
     }
 
     return changed

--- a/packages/lixpi/canvas-components-lixpi-specific/src/shared/generation/workspace-media-analysis.ts
+++ b/packages/lixpi/canvas-components-lixpi-specific/src/shared/generation/workspace-media-analysis.ts
@@ -149,7 +149,8 @@ export class WorkspaceMediaAnalysis {
         this.analysis.clear()
         this.refreshes.clear()
 
-        for (const work of pending) work.cancelTimer?.()
+        for (const work of pending)
+            work.cancelTimer?.()
     }
 
     destroy(): void {

--- a/packages/lixpi/canvas-components-lixpi-specific/src/shared/generation/workspace-preflight-markers.ts
+++ b/packages/lixpi/canvas-components-lixpi-specific/src/shared/generation/workspace-preflight-markers.ts
@@ -311,7 +311,8 @@ export class WorkspacePreflightMarkers {
         if (!this.isCurrent(scope))
             return
 
-        for (const mutate of recordMutations) mutate()
+        for (const mutate of recordMutations)
+            mutate()
 
         this.ports.commit({
             ...currentCanvasState,
@@ -477,7 +478,8 @@ export class WorkspacePreflightMarkers {
         if (!this.isCurrent(scope))
             return
 
-        for (const mutate of recordMutations) mutate()
+        for (const mutate of recordMutations)
+            mutate()
 
         this.ports.commit({
             ...currentCanvasState,
@@ -632,7 +634,8 @@ export class WorkspacePreflightMarkers {
         if (!this.isCurrent(scope))
             return
 
-        for (const mutate of recordMutations) mutate()
+        for (const mutate of recordMutations)
+            mutate()
 
         this.ports.commit({
             ...currentCanvasState,

--- a/packages/lixpi/canvas-components-lixpi-specific/src/shared/scene/workspace-api-canvas-geometry.ts
+++ b/packages/lixpi/canvas-components-lixpi-specific/src/shared/scene/workspace-api-canvas-geometry.ts
@@ -104,8 +104,9 @@ const reconcileApiBranchMarkersWithTemporaryPreflightNodes = (
     const cleanupBranchMarkerArtifacts = (nodeIds: Iterable<string>) => {
         const removed = new Set(nodeIds)
 
-        for (const [key, record] of pendingBranchMarkers) if (removed.has(record.nodeId))
-            pendingBranchMarkers.delete(key)
+        for (const [key, record] of pendingBranchMarkers)
+            if (removed.has(record.nodeId))
+                pendingBranchMarkers.delete(key)
     }
     const plannedMarkers = (canvasGeometry.nodeSnapshots ?? []).filter((node: CanvasNode): node is BranchMarkerNode => isBranchMarkerNode(node)).filter(
         node =>
@@ -483,7 +484,8 @@ export class WorkspaceApiCanvasGeometry {
 
             this.ports.placements.markers.clear()
 
-            for (const [key, record] of preflight.records) this.ports.placements.markers.set(key, record)
+            for (const [key, record] of preflight.records)
+                this.ports.placements.markers.set(key, record)
         }
 
         if (result.fullyApplied)

--- a/packages/lixpi/canvas-components/src/frontend/effects/glass/dom-glass-border.ts
+++ b/packages/lixpi/canvas-components/src/frontend/effects/glass/dom-glass-border.ts
@@ -50,7 +50,8 @@ export class DomGlassBorder {
         this.targets = [...targets]
         this.radii.clear()
 
-        for (const target of targets) this.observer.observe(target.element)
+        for (const target of targets)
+            this.observer.observe(target.element)
 
         this.options.surface.invalidate()
     }

--- a/packages/lixpi/canvas-components/src/frontend/effects/glass/glass-border.ts
+++ b/packages/lixpi/canvas-components/src/frontend/effects/glass/glass-border.ts
@@ -208,7 +208,8 @@ export class GlassBorder {
             )
             resources.setVisible(this.root, false)
         } catch (error) {
-            for (const handle of owned.reverse()) resources.release(handle)
+            for (const handle of owned.reverse())
+                resources.release(handle)
 
             throw error
         }
@@ -426,8 +427,9 @@ export class GlassBorder {
             datums.map(datum => datum.id),
         )
 
-        for (const [id, entry] of this.entries) if (!ids.has(id))
-            resources.setVisible(entry.mesh, false)
+        for (const [id, entry] of this.entries)
+            if (!ids.has(id))
+                resources.setVisible(entry.mesh, false)
 
         for (const datum of datums) {
             let entry = this.entries.get(datum.id)

--- a/packages/lixpi/canvas-components/src/frontend/media/native-playback.ts
+++ b/packages/lixpi/canvas-components/src/frontend/media/native-playback.ts
@@ -241,7 +241,8 @@ export class NativePlayback {
         this.element.addEventListener('loadedmetadata', this.onMetadata)
         this.element.addEventListener('error', this.onMediaError)
 
-        for (const event of ['play', 'pause', 'ended']) this.element.addEventListener(event, this.onPlaybackChange)
+        for (const event of ['play', 'pause', 'ended'])
+            this.element.addEventListener(event, this.onPlaybackChange)
 
         options.root.appendChild(this.element)
         options.signal.addEventListener(
@@ -362,7 +363,8 @@ export class NativePlayback {
         this.element.removeEventListener('loadedmetadata', this.onMetadata)
         this.element.removeEventListener('error', this.onMediaError)
 
-        for (const event of ['play', 'pause', 'ended']) this.element.removeEventListener(event, this.onPlaybackChange)
+        for (const event of ['play', 'pause', 'ended'])
+            this.element.removeEventListener(event, this.onPlaybackChange)
 
         this.pause()
         this.element.removeAttribute('src')

--- a/packages/lixpi/canvas-engine/src/frontend/connectors/connection-manager.ts
+++ b/packages/lixpi/canvas-engine/src/frontend/connectors/connection-manager.ts
@@ -307,8 +307,9 @@ export class ConnectionManager<Node extends ConnectionNode = ConnectionNode> {
             canvasNodes.map(node => node.nodeId),
         )
 
-        for (const id of this.nodeElements.keys()) if (!nodeIds.has(id))
-            this.nodeElements.delete(id)
+        for (const id of this.nodeElements.keys())
+            if (!nodeIds.has(id))
+                this.nodeElements.delete(id)
 
         // xyflow's adoptUserNodes requires parents to appear BEFORE their children in the
         // input array; otherwise it logs a warning and skips parent linkage. Stable
@@ -1106,7 +1107,8 @@ export class ConnectionManager<Node extends ConnectionNode = ConnectionNode> {
                 },
             )
 
-            for (const additional of this.config.additionalGeometry?.(canvasNode, this.nodes) ?? []) worldNodeMap.set(additional.id, additional)
+            for (const additional of this.config.additionalGeometry?.(canvasNode, this.nodes) ?? [])
+                worldNodeMap.set(additional.id, additional)
         }
 
         // Get current zoom for proportional scaling

--- a/packages/lixpi/canvas-engine/src/frontend/connectors/connector-renderer.ts
+++ b/packages/lixpi/canvas-engine/src/frontend/connectors/connector-renderer.ts
@@ -91,8 +91,9 @@ export class ConnectorRenderer {
             edges.map(edge => edge.id),
         )
 
-        for (const [id, entry] of this.entries) if (!incoming.has(id))
-            resources.setVisible(entry.group, false)
+        for (const [id, entry] of this.entries)
+            if (!incoming.has(id))
+                resources.setVisible(entry.group, false)
 
         for (const edge of edges) {
             let entry = this.entries.get(edge.id)
@@ -149,7 +150,8 @@ export class ConnectorRenderer {
             const marker = this.options.marker
             const arrows = marker ? [edge.arrowStart, edge.arrowEnd].filter((arrow): arrow is ConnectorArrow => arrow !== null) : []
 
-            for (const [index, arrowEntry] of entry.arrows.entries()) resources.setVisible(arrowEntry.group, index < arrows.length)
+            for (const [index, arrowEntry] of entry.arrows.entries())
+                resources.setVisible(arrowEntry.group, index < arrows.length)
 
             for (const [index, arrow] of arrows.entries()) {
                 let arrowEntry = entry.arrows[index]

--- a/packages/lixpi/canvas-engine/src/frontend/media/canvas-media.ts
+++ b/packages/lixpi/canvas-engine/src/frontend/media/canvas-media.ts
@@ -328,7 +328,8 @@ export class CanvasMedia implements EngineMedia {
 
         for (const entry of Array.from(
             this.entries.values(),
-        )) this.discard(entry)
+        ))
+            this.discard(entry)
 
         this.decoder.destroy()
     }

--- a/packages/lixpi/canvas-engine/src/frontend/media/image-decoder.ts
+++ b/packages/lixpi/canvas-engine/src/frontend/media/image-decoder.ts
@@ -168,11 +168,13 @@ export class ImageDecoder {
 
         this.destroyed = true
 
-        for (const id of this.pending.keys()) this.take(id)?.reject(
-            new DOMException('Image decoder destroyed', 'AbortError'),
-        )
+        for (const id of this.pending.keys())
+            this.take(id)?.reject(
+                new DOMException('Image decoder destroyed', 'AbortError'),
+            )
 
-        for (const worker of this.workers) worker.terminate()
+        for (const worker of this.workers)
+            worker.terminate()
 
         this.workers.length = 0
     }

--- a/packages/lixpi/canvas-engine/src/frontend/rendering/pixi-drawing-resources.ts
+++ b/packages/lixpi/canvas-engine/src/frontend/rendering/pixi-drawing-resources.ts
@@ -120,7 +120,8 @@ export class PixiDrawingResources implements DrawingResources {
 
         this.viewport = { ...viewport }
 
-        for (const layer of this.layers.values()) this.applyViewport(layer.world)
+        for (const layer of this.layers.values())
+            this.applyViewport(layer.world)
 
         this.invalidateCaptures()
         this.invalidate()
@@ -258,8 +259,9 @@ export class PixiDrawingResources implements DrawingResources {
 
         resource.update(input)
 
-        for (const [container, textures] of this.samples) if (textures.includes(handle))
-            this.changed(container)
+        for (const [container, textures] of this.samples)
+            if (textures.includes(handle))
+                this.changed(container)
 
         this.invalidate()
     }
@@ -417,9 +419,10 @@ export class PixiDrawingResources implements DrawingResources {
             if (shape.fill) {
                 graphics.beginPath().path(path).fill(shape.fill)
 
-                for (const hole of shape.holes ?? []) graphics.beginPath().path(
-                    projectVectorPath(hole, shape.projection),
-                ).cut()
+                for (const hole of shape.holes ?? [])
+                    graphics.beginPath().path(
+                        projectVectorPath(hole, shape.projection),
+                    ).cut()
             }
 
             if (shape.stroke) {
@@ -436,10 +439,11 @@ export class PixiDrawingResources implements DrawingResources {
 
         this.changed(graphics)
 
-        for (const [group, mask] of this.masks) if (mask === handle)
-            this.changed(
-                this.display(group),
-            )
+        for (const [group, mask] of this.masks)
+            if (mask === handle)
+                this.changed(
+                    this.display(group),
+                )
 
         this.invalidate()
     }
@@ -536,9 +540,11 @@ export class PixiDrawingResources implements DrawingResources {
         )
             throw new RangeError('Capture bounds and resolution must be finite and positive')
 
-        for (const handle of input.include) this.registry.get(handle, handle.kind)
+        for (const handle of input.include)
+            this.registry.get(handle, handle.kind)
 
-        for (const handle of input.exclude) this.registry.get(handle, 'group')
+        for (const handle of input.exclude)
+            this.registry.get(handle, 'group')
 
         for (const bounds of input.sampleBounds ?? []) {
             if (
@@ -632,8 +638,9 @@ export class PixiDrawingResources implements DrawingResources {
         parent: Container,
         child: Container,
     ): boolean {
-        for (let node: Container | null = child; node; node = node.parent) if (node === parent)
-            return true
+        for (let node: Container | null = child; node; node = node.parent)
+            if (node === parent)
+                return true
 
         return false
     }
@@ -655,7 +662,8 @@ export class PixiDrawingResources implements DrawingResources {
         const bounds = container.getBounds().rectangle
         const ancestors = new Set<Container>()
 
-        for (let node: Container | null = container; node; node = node.parent) ancestors.add(node)
+        for (let node: Container | null = container; node; node = node.parent)
+            ancestors.add(node)
 
         const previous = this.changes.get(container)
         const x = Math.min(bounds.x, previous?.bounds.x ?? bounds.x)
@@ -663,7 +671,8 @@ export class PixiDrawingResources implements DrawingResources {
         const right = Math.max(bounds.right, previous ? previous.bounds.x + previous.bounds.width : bounds.right)
         const bottom = Math.max(bounds.bottom, previous ? previous.bounds.y + previous.bounds.height : bounds.bottom)
 
-        for (const ancestor of previous?.ancestors ?? []) ancestors.add(ancestor)
+        for (const ancestor of previous?.ancestors ?? [])
+            ancestors.add(ancestor)
 
         this.changes.set(
             container,
@@ -774,7 +783,8 @@ export class PixiDrawingResources implements DrawingResources {
             ordered.push(capture)
         }
 
-        for (const capture of this.captures.values()) visit(capture)
+        for (const capture of this.captures.values())
+            visit(capture)
 
         const refreshed = new Set<Capture>()
 
@@ -814,7 +824,8 @@ export class PixiDrawingResources implements DrawingResources {
             )
                 node.renderable = false
 
-            for (const child of node.children) visit(child)
+            for (const child of node.children)
+                visit(child)
         }
 
         try {
@@ -835,16 +846,19 @@ export class PixiDrawingResources implements DrawingResources {
                 transform: new Matrix().translate(-capture.spec.bounds.x, -capture.spec.bounds.y),
             })
         } finally {
-            for (const [node, renderable] of visibility) node.renderable = renderable
+            for (const [node, renderable] of visibility)
+                node.renderable = renderable
 
             if (capture.spec.space === 'world') {
-                for (const layer of this.layers.values()) this.applyViewport(layer.world)
+                for (const layer of this.layers.values())
+                    this.applyViewport(layer.world)
             }
         }
     }
 
     prepareProjection(bounds: CanvasEngineRect): void {
-        for (const mesh of this.meshes.values()) mesh.prepareProjection(bounds)
+        for (const mesh of this.meshes.values())
+            mesh.prepareProjection(bounds)
     }
 
     release(handle: ResourceHandle): void {

--- a/packages/lixpi/canvas-engine/src/frontend/rendering/pixi-material-resource.ts
+++ b/packages/lixpi/canvas-engine/src/frontend/rendering/pixi-material-resource.ts
@@ -67,9 +67,11 @@ export class PixiMaterialResource {
             this.gpu.destroy()
             gl?.destroy()
 
-            for (const sampler of this.samplers.values()) sampler.destroy()
+            for (const sampler of this.samplers.values())
+                sampler.destroy()
 
-            for (const uniform of this.uniforms.values()) uniform.buffer?.destroy()
+            for (const uniform of this.uniforms.values())
+                uniform.buffer?.destroy()
 
             throw error
         }
@@ -186,7 +188,8 @@ export class PixiMaterialResource {
                 : { ...binding },
         )
 
-        for (const instance of this.instances) this.apply(instance.shader)
+        for (const instance of this.instances)
+            this.apply(instance.shader)
     }
 
     createInstance(): MaterialInstance {
@@ -239,11 +242,14 @@ export class PixiMaterialResource {
     }
 
     destroy(): void {
-        for (const instance of Array.from(this.instances)) this.releaseInstance(instance)
+        for (const instance of Array.from(this.instances))
+            this.releaseInstance(instance)
 
-        for (const sampler of this.samplers.values()) sampler.destroy()
+        for (const sampler of this.samplers.values())
+            sampler.destroy()
 
-        for (const uniform of this.uniforms.values()) uniform.buffer?.destroy()
+        for (const uniform of this.uniforms.values())
+            uniform.buffer?.destroy()
 
         this.samplers.clear()
         this.uniforms.clear()

--- a/packages/lixpi/canvas-engine/src/frontend/rendering/pixi-mesh-resource.ts
+++ b/packages/lixpi/canvas-engine/src/frontend/rendering/pixi-mesh-resource.ts
@@ -66,7 +66,8 @@ export class PixiMeshResource {
         slot.geometry.getBuffer('aUV').update()
         slot.geometry.getIndex().update()
 
-        for (const entry of this.slots) entry.mesh.renderable = entry === slot
+        for (const entry of this.slots)
+            entry.mesh.renderable = entry === slot
     }
 
     setPaint(paint: Texture | PixiMaterialResource): void {
@@ -75,7 +76,8 @@ export class PixiMeshResource {
 
         this.paint = paint
 
-        for (const slot of this.slots) this.applyPaint(slot)
+        for (const slot of this.slots)
+            this.applyPaint(slot)
     }
 
     prepareProjection(bounds: CanvasEngineRect): void {
@@ -148,7 +150,8 @@ export class PixiMeshResource {
             this.slots.push(slot)
         }
 
-        for (const slot of previous) this.container.removeChild(slot.mesh)
+        for (const slot of previous)
+            this.container.removeChild(slot.mesh)
 
         if (previous.length > 0)
             this.retire(() => this.destroySlots(previous))

--- a/packages/lixpi/canvas-engine/src/frontend/rendering/pixi-vector-path.ts
+++ b/packages/lixpi/canvas-engine/src/frontend/rendering/pixi-vector-path.ts
@@ -54,7 +54,8 @@ export const projectVectorPath = (
                         ? 6
                         : 0
 
-            for (let i = 0; i < length; i++) data[i] = Math.round(data[i] * snapResolution) / snapResolution
+            for (let i = 0; i < length; i++)
+                data[i] = Math.round(data[i] * snapResolution) / snapResolution
 
             if (action === 'arcToSvg') {
                 data[5] = Math.round(data[5] * snapResolution) / snapResolution

--- a/packages/lixpi/canvas-engine/src/frontend/rendering/resource-registry.ts
+++ b/packages/lixpi/canvas-engine/src/frontend/rendering/resource-registry.ts
@@ -43,7 +43,8 @@ export class ResourceRegistry {
         if (options.parent)
             this.entry(options.parent)
 
-        for (const dependency of dependencies) this.entry(dependency)
+        for (const dependency of dependencies)
+            this.entry(dependency)
 
         const handle = Object.freeze({
             id: `resource-${++this.counter}`,
@@ -63,7 +64,8 @@ export class ResourceRegistry {
             },
         )
 
-        for (const dependency of dependencies) this.entries.get(dependency)!.dependents.add(handle)
+        for (const dependency of dependencies)
+            this.entries.get(dependency)!.dependents.add(handle)
 
         if (options.parent)
             this.entries.get(options.parent)!.children.add(handle)
@@ -101,7 +103,8 @@ export class ResourceRegistry {
         const previous = entry.dependencies
         entry.dependencies = next
 
-        for (const dependency of next) this.entries.get(dependency)!.dependents.add(handle)
+        for (const dependency of next)
+            this.entries.get(dependency)!.dependents.add(handle)
 
         for (const dependency of previous) {
             if (next.has(dependency))
@@ -129,7 +132,8 @@ export class ResourceRegistry {
 
         entry.released = true
 
-        for (const child of Array.from(entry.children)) this.release(child)
+        for (const child of Array.from(entry.children))
+            this.release(child)
 
         this.collect(handle)
     }
@@ -206,6 +210,7 @@ export class ResourceRegistry {
 
         for (const handle of Array.from(
             this.entries.keys(),
-        ).reverse()) this.release(handle)
+        ).reverse())
+            this.release(handle)
     }
 }

--- a/packages/lixpi/canvas-engine/src/frontend/rendering/resource-validation.ts
+++ b/packages/lixpi/canvas-engine/src/frontend/rendering/resource-validation.ts
@@ -26,14 +26,17 @@ export const validateMesh = (data: MeshData): void => {
 
     const vertices = data.positions.length / 2
 
-    for (const value of data.positions) if (!Number.isFinite(value))
-        throw new RangeError('Mesh positions must be finite')
+    for (const value of data.positions)
+        if (!Number.isFinite(value))
+            throw new RangeError('Mesh positions must be finite')
 
-    for (const value of data.uvs) if (!Number.isFinite(value))
-        throw new RangeError('Mesh UVs must be finite')
+    for (const value of data.uvs)
+        if (!Number.isFinite(value))
+            throw new RangeError('Mesh UVs must be finite')
 
-    for (const index of data.indices) if (index >= vertices)
-        throw new RangeError('Mesh index exceeds the vertex count')
+    for (const index of data.indices)
+        if (index >= vertices)
+            throw new RangeError('Mesh index exceeds the vertex count')
 }
 
 export const validateTexture = (input: TextureInput): void => {
@@ -103,8 +106,9 @@ export const validateMaterialBindings = (bindings: readonly MaterialBinding[]): 
         )
             throw new RangeError(`Invalid value length for ${binding.name}`)
 
-        for (const value of values) if (!Number.isFinite(value))
-            throw new RangeError(`Non-finite uniform ${binding.name}`)
+        for (const value of values)
+            if (!Number.isFinite(value))
+                throw new RangeError(`Non-finite uniform ${binding.name}`)
     }
 }
 

--- a/packages/lixpi/canvas-engine/src/frontend/runtime/canvas-controller.ts
+++ b/packages/lixpi/canvas-engine/src/frontend/runtime/canvas-controller.ts
@@ -180,7 +180,8 @@ export class CanvasController {
             })
             this.lifetime.own(() => this.gestures.destroy())
             this.lifetime.own(() => {
-                for (const handle of this.handles.values()) handle.destroy()
+                for (const handle of this.handles.values())
+                    handle.destroy()
 
                 this.handles.clear()
             })
@@ -197,7 +198,8 @@ export class CanvasController {
             this.setViewport(options.viewport)
             this.setScene(options.scene)
 
-            for (const extension of options.extensions ?? []) this.installExtension(extension)
+            for (const extension of options.extensions ?? [])
+                this.installExtension(extension)
 
             this.ready = this.initialize()
         } catch (error) {
@@ -619,7 +621,8 @@ export class CanvasController {
                 })
         }
 
-        for (const intent of intents) this.emit(intent)
+        for (const intent of intents)
+            this.emit(intent)
     }
 
     setScene(snapshot: SceneSnapshot): void {
@@ -638,8 +641,9 @@ export class CanvasController {
         if (changedScene) {
             this.selection.clear()
             this.selectedEdge = null
-        } else for (const id of this.selection.nodeIds) if (!snapshot.nodes.some(node => node.nodeId === id))
-            this.selection.remove(id)
+        } else for (const id of this.selection.nodeIds)
+            if (!snapshot.nodes.some(node => node.nodeId === id))
+                this.selection.remove(id)
 
         this.connections?.syncEdges(
             snapshot.edges.map(

--- a/packages/lixpi/canvas-engine/src/frontend/runtime/canvas-scene.ts
+++ b/packages/lixpi/canvas-engine/src/frontend/runtime/canvas-scene.ts
@@ -353,10 +353,8 @@ export class CanvasScene {
                 connectorBounds: worldBounds,
             }
 
-            for (const key of ['visualBounds', 'hitBounds', 'selectionBounds', 'collisionBounds', 'connectorBounds'] as const) assertCanvasBounds(
-                measurement[key],
-                node.nodeId,
-            )
+            for (const key of ['visualBounds', 'hitBounds', 'selectionBounds', 'collisionBounds', 'connectorBounds'] as const)
+                assertCanvasBounds(measurement[key], node.nodeId)
 
             boundsById.set(
                 node.nodeId,
@@ -582,7 +580,8 @@ export class CanvasScene {
             this.prefetch = new IdleTask({
                 signal: this.lifetime.signal,
                 callback: () => {
-                    for (const node of candidates.splice(0, batchSize)) void this.prefetchNode(node.nodeId)
+                    for (const node of candidates.splice(0, batchSize))
+                        void this.prefetchNode(node.nodeId)
 
                     if (
                         candidates.length

--- a/packages/lixpi/canvas-engine/src/frontend/runtime/geometry-overrides.ts
+++ b/packages/lixpi/canvas-engine/src/frontend/runtime/geometry-overrides.ts
@@ -132,7 +132,8 @@ export class GeometryOverrides {
 
     // A scene switch expires old writers, including delayed gesture callbacks.
     clear(): void {
-        for (const scope of Array.from(this.scopes)) scope.destroy()
+        for (const scope of Array.from(this.scopes))
+            scope.destroy()
     }
 
     destroy(): void {

--- a/packages/lixpi/canvas-engine/src/frontend/runtime/gesture-controller.ts
+++ b/packages/lixpi/canvas-engine/src/frontend/runtime/gesture-controller.ts
@@ -130,7 +130,8 @@ export class CanvasGesture {
         )
             this.capture.releasePointerCapture(this.pointerId)
 
-        for (const style of this.styles) style.destroy()
+        for (const style of this.styles)
+            style.destroy()
 
         this.release()
     }

--- a/packages/lixpi/canvas-engine/src/frontend/runtime/node-views.ts
+++ b/packages/lixpi/canvas-engine/src/frontend/runtime/node-views.ts
@@ -231,7 +231,8 @@ export class NodeViews {
     private clear(): void {
         for (const id of Array.from(
             this.mounted.keys(),
-        )) this.remove(id)
+        ))
+            this.remove(id)
     }
 
     destroy(): void {

--- a/packages/lixpi/canvas-engine/src/frontend/runtime/scroll-lock.ts
+++ b/packages/lixpi/canvas-engine/src/frontend/runtime/scroll-lock.ts
@@ -12,7 +12,8 @@ export class CanvasScrollLock {
             layers.filter((layer): layer is HTMLElement => Boolean(layer)),
         )]
 
-        for (const layer of this.layers) layer.addEventListener('scroll', this.resetScroll)
+        for (const layer of this.layers)
+            layer.addEventListener('scroll', this.resetScroll)
     }
 
     private resetScroll = (event: Event): void => {
@@ -26,7 +27,8 @@ export class CanvasScrollLock {
     }
 
     destroy = (): void => {
-        for (const layer of this.layers) layer.removeEventListener('scroll', this.resetScroll)
+        for (const layer of this.layers)
+            layer.removeEventListener('scroll', this.resetScroll)
 
         this.layers.length = 0
     }

--- a/packages/lixpi/canvas-engine/src/frontend/viewport/viewport-bridge.ts
+++ b/packages/lixpi/canvas-engine/src/frontend/viewport/viewport-bridge.ts
@@ -18,9 +18,11 @@ export class ViewportBridge {
         const transform = `translate(${viewport.x}px, ${viewport.y}px) scale(${viewport.zoom})`
         applyStyle(this.options.viewportEl, { transform })
 
-        for (const overlayEl of this.options.viewportOverlayEls ?? []) applyStyle(overlayEl, { transform })
+        for (const overlayEl of this.options.viewportOverlayEls ?? [])
+            applyStyle(overlayEl, { transform })
 
-        for (const target of this.options.targets?.() ?? []) target?.setViewport(viewport)
+        for (const target of this.options.targets?.() ?? [])
+            target?.setViewport(viewport)
     }
 }
 

--- a/packages/lixpi/canvas-engine/src/shared/scene/parent-order.ts
+++ b/packages/lixpi/canvas-engine/src/shared/scene/parent-order.ts
@@ -4,7 +4,8 @@ export const topoSortByParent = <T extends {
 }>(nodes: readonly T[]): T[] => {
     const byId = new Map<string, T>()
 
-    for (const n of nodes) byId.set(n.nodeId, n)
+    for (const n of nodes)
+        byId.set(n.nodeId, n)
 
     const sorted: T[] = []
     const visiting = new Set<string>()
@@ -30,7 +31,8 @@ export const topoSortByParent = <T extends {
         sorted.push(n)
     }
 
-    for (const n of nodes) visit(n)
+    for (const n of nodes)
+        visit(n)
 
     return sorted
 }

--- a/packages/lixpi/canvas-engine/src/shared/scene/validation.ts
+++ b/packages/lixpi/canvas-engine/src/shared/scene/validation.ts
@@ -113,7 +113,8 @@ export const validateScene = (scene: SceneSnapshot): void => {
             current = nodes.get(current.parentId)!
         }
 
-        for (const id of ancestors) resolved.add(id)
+        for (const id of ancestors)
+            resolved.add(id)
     }
 
     const edgeIds = new Set<string>()

--- a/packages/lixpi/canvas-engine/src/shared/tree-layout/layout-tree.ts
+++ b/packages/lixpi/canvas-engine/src/shared/tree-layout/layout-tree.ts
@@ -87,7 +87,8 @@ export const layoutTree = (
     // stacking is deterministic.
     const byId = new Map<string, TreeLayoutNode>()
 
-    for (const node of nodes) byId.set(node.id, node)
+    for (const node of nodes)
+        byId.set(node.id, node)
 
     const childrenByParent = new Map<string, TreeLayoutNode[]>()
     const roots: TreeLayoutNode[] = []
@@ -129,7 +130,8 @@ export const layoutTree = (
 
         let stack = 0
 
-        for (const child of children) stack += computeBand(child)
+        for (const child of children)
+            stack += computeBand(child)
 
         stack += siblingGap * (children.length - 1)
 
@@ -167,7 +169,8 @@ export const layoutTree = (
         const band = bandHeight.get(node.id) ?? node.height
         let stack = 0
 
-        for (const child of children) stack += bandHeight.get(child.id) ?? child.height
+        for (const child of children)
+            stack += bandHeight.get(child.id) ?? child.height
 
         stack += siblingGap * (children.length - 1)
 

--- a/packages/lixpi/capability-system/src/backend/capability-dag-runner.ts
+++ b/packages/lixpi/capability-system/src/backend/capability-dag-runner.ts
@@ -28,7 +28,8 @@ export class CapabilityDagRunner<Node extends CapabilityDagNode> {
         )
         this.validate(nodes)
 
-        for (const node of nodes) this.statuses.set(node.nodeId, 'pending')
+        for (const node of nodes)
+            this.statuses.set(node.nodeId, 'pending')
     }
 
     hasPending(): boolean {
@@ -140,12 +141,14 @@ export class CapabilityDagRunner<Node extends CapabilityDagNode> {
             const node = this.nodesById.get(nodeId)
                 ?? nodes.find(candidate => candidate.nodeId === nodeId)
 
-            for (const dependency of node?.dependsOn ?? []) visit(dependency)
+            for (const dependency of node?.dependsOn ?? [])
+                visit(dependency)
 
             visiting.delete(nodeId)
             visited.add(nodeId)
         }
 
-        for (const node of nodes) visit(node.nodeId)
+        for (const node of nodes)
+            visit(node.nodeId)
     }
 }

--- a/packages/lixpi/capability-system/src/backend/capability-module.ts
+++ b/packages/lixpi/capability-system/src/backend/capability-module.ts
@@ -83,13 +83,15 @@ export class CapabilityModuleCatalog {
 
     registerActions(registry: CapabilityActionRegistry): void {
         for (const definition of this.modules.values()) {
-            for (const installer of definition.tools) installer.registerActions(registry)
+            for (const installer of definition.tools)
+                installer.registerActions(registry)
         }
     }
 
     registerMediaStrategies(registry: CapabilityMediaStrategyRegistry): void {
         for (const definition of this.modules.values()) {
-            for (const strategy of definition.mediaStrategies ?? []) registry.register(strategy)
+            for (const strategy of definition.mediaStrategies ?? [])
+                registry.register(strategy)
         }
     }
 
@@ -101,9 +103,11 @@ export class CapabilityModuleCatalog {
                 catalogExposure: 'module-internal',
             }
 
-            for (const installer of definition.skills) await installer.seed(context)
+            for (const installer of definition.skills)
+                await installer.seed(context)
 
-            for (const installer of definition.tools) await installer.seed(context)
+            for (const installer of definition.tools)
+                await installer.seed(context)
         }
     }
 
@@ -346,11 +350,12 @@ export function validateDescriptionSheet(
 
     const inputNames = new Set<string>()
 
-    for (const input of sheet.expectedInputs) validateExpectedInput(
-        moduleId,
-        input,
-        inputNames,
-    )
+    for (const input of sheet.expectedInputs)
+        validateExpectedInput(
+            moduleId,
+            input,
+            inputNames,
+        )
 
     validateDescriptionList(
         moduleId,

--- a/packages/lixpi/capability-system/src/backend/capability-resolver.ts
+++ b/packages/lixpi/capability-system/src/backend/capability-resolver.ts
@@ -428,7 +428,8 @@ function deepFreeze<T>(value: T): T {
 
     Object.freeze(value)
 
-    for (const child of Object.values(value)) deepFreeze(child)
+    for (const child of Object.values(value))
+        deepFreeze(child)
 
     return value
 }

--- a/packages/lixpi/capability-system/src/capabilities/action-timeline/frontend/action-timeline-frontend.ts
+++ b/packages/lixpi/capability-system/src/capabilities/action-timeline/frontend/action-timeline-frontend.ts
@@ -393,7 +393,8 @@ function createActionTimelineCanvasView(host: CapabilityArtifactCanvasHost): Cap
     let referenceViews: Array<{ destroy: () => void }> = []
 
     const destroyReferenceViews = (): void => {
-        for (const view of referenceViews) view.destroy()
+        for (const view of referenceViews)
+            view.destroy()
 
         referenceViews = []
     }
@@ -572,7 +573,8 @@ function renderInlineContent(
             }
         }
 
-        for (const nested of child.content ?? []) visit(nested)
+        for (const nested of child.content ?? [])
+            visit(nested)
     }
     visit(node)
 }

--- a/packages/lixpi/capability-system/src/capabilities/action-timeline/shared/action-timeline.ts
+++ b/packages/lixpi/capability-system/src/capabilities/action-timeline/shared/action-timeline.ts
@@ -263,7 +263,8 @@ export const assertActionTimelineRuns = (
     segments: readonly ActionTimelineGeneratedSegment[],
     authorizedReferenceAssetIds: ReadonlySet<string>,
 ): void => {
-    for (const segment of segments) assertRuns(segment.runs, authorizedReferenceAssetIds)
+    for (const segment of segments)
+        assertRuns(segment.runs, authorizedReferenceAssetIds)
 }
 
 export const buildActionTimelineDocument = (
@@ -642,7 +643,8 @@ function walkNodes(
 ): void {
     visitor(node)
 
-    for (const child of node.content ?? []) walkNodes(child, visitor)
+    for (const child of node.content ?? [])
+        walkNodes(child, visitor)
 }
 
 function collectInlineText(

--- a/packages/lixpi/capability-system/src/capabilities/character-creator/backend/runtime/character-sheet-strategy.ts
+++ b/packages/lixpi/capability-system/src/capabilities/character-creator/backend/runtime/character-sheet-strategy.ts
@@ -870,7 +870,8 @@ const summarizeEvidence = (evidence: CharacterEvidenceProfile): string => {
 const summarizeReferencePack = (entries: CharacterReferencePack['entries']): string => {
     const counts = new Map<string, number>()
 
-    for (const entry of entries) counts.set(entry.role, (counts.get(entry.role) ?? 0) + 1)
+    for (const entry of entries)
+        counts.set(entry.role, (counts.get(entry.role) ?? 0) + 1)
 
     const roles = [...counts.entries()].map(([role, count]) => `${role} ×${count}`).join(', ')
 
@@ -1430,7 +1431,8 @@ export class CharacterSheetStrategy implements CapabilityMediaStrategy {
                         visiblePanels.set(panelId, rendered.bytes)
                 }
 
-                for (const [panelId, bytes] of livePartialPanels) visiblePanels.set(panelId, bytes)
+                for (const [panelId, bytes] of livePartialPanels)
+                    visiblePanels.set(panelId, bytes)
 
                 if (visiblePanels.size === 0)
                     return
@@ -1848,7 +1850,8 @@ export class CharacterSheetStrategy implements CapabilityMediaStrategy {
                     && panel.panelId !== observedPropSpec?.panelId
             })
 
-            for (const panel of assessablePanels) assessmentEligiblePanelIds.add(panel.panelId)
+            for (const panel of assessablePanels)
+                assessmentEligiblePanelIds.add(panel.panelId)
 
             await reportProgress({
                 phase: 'assessing',

--- a/packages/lixpi/capability-system/src/capabilities/character-creator/backend/runtime/reference-resolver.ts
+++ b/packages/lixpi/capability-system/src/capabilities/character-creator/backend/runtime/reference-resolver.ts
@@ -77,7 +77,8 @@ export const resolveCharacterReferences = async (args: {
                 composition?.kind === 'character-sheet'
                 && composition.capabilityId === 'global.character-creator'
             ) {
-                for (const sourceAssetId of composition.sourceAssetIds) await resolveAsset(sourceAssetId)
+                for (const sourceAssetId of composition.sourceAssetIds)
+                    await resolveAsset(sourceAssetId)
 
                 for (const component of composition.components) {
                     if (component.role === 'character-sheet-panel-review-only')
@@ -190,7 +191,8 @@ export const resolveCharacterReferences = async (args: {
         }
     }
 
-    for (const assetId of args.assetIds) await resolveAsset(assetId)
+    for (const assetId of args.assetIds)
+        await resolveAsset(assetId)
 
     return resolved
 }

--- a/packages/lixpi/capability-system/src/capabilities/character-creator/shared/character-sheet-media-plan.ts
+++ b/packages/lixpi/capability-system/src/capabilities/character-creator/shared/character-sheet-media-plan.ts
@@ -529,13 +529,15 @@ function assertAcyclicPanels(panels: CharacterPanelSpec[]): void {
 
         visiting.add(panelId)
 
-        for (const dependency of panelsById.get(panelId)?.dependsOn ?? []) visit(dependency)
+        for (const dependency of panelsById.get(panelId)?.dependsOn ?? [])
+            visit(dependency)
 
         visiting.delete(panelId)
         visited.add(panelId)
     }
 
-    for (const panel of panels) visit(panel.panelId)
+    for (const panel of panels)
+        visit(panel.panelId)
 }
 
 export const isCapabilityMediaExecutionPlan = (value: CapabilityJsonValue | unknown): value is CharacterSheetRenderPlan => {

--- a/packages/lixpi/capability-system/src/frontend/capability-catalog-client.ts
+++ b/packages/lixpi/capability-system/src/frontend/capability-catalog-client.ts
@@ -467,7 +467,8 @@ export class CapabilityCatalogClient {
                 cursor: rawPage.cursor,
             }
 
-            for (const item of page.items) this.catalogItems.set(item.capabilityId, item)
+            for (const item of page.items)
+                this.catalogItems.set(item.capabilityId, item)
 
             this.cache.set(
                 cacheKey,

--- a/packages/lixpi/capability-system/src/shared/capability-json-schema.ts
+++ b/packages/lixpi/capability-system/src/shared/capability-json-schema.ts
@@ -89,14 +89,15 @@ function validateNode(
         errors.push(`${path}: value does not match const`)
 
     if (Array.isArray(schema.allOf)) {
-        for (const child of schema.allOf) validateNode(
-            child,
-            value,
-            path,
-            errors,
-            depth + 1,
-            rootSchema,
-        )
+        for (const child of schema.allOf)
+            validateNode(
+                child,
+                value,
+                path,
+                errors,
+                depth + 1,
+                rootSchema,
+            )
     }
 
     if (Array.isArray(schema.anyOf)) {

--- a/packages/lixpi/capability-system/src/shared/capability-validation.ts
+++ b/packages/lixpi/capability-system/src/shared/capability-validation.ts
@@ -321,7 +321,8 @@ export const validateCapabilityDependencyGraph = (
         visiting.pop()
     }
 
-    for (const rootCapabilityId of rootCapabilityIds) visit(rootCapabilityId, 1)
+    for (const rootCapabilityId of rootCapabilityIds)
+        visit(rootCapabilityId, 1)
 
     return deduplicateIssues(issues)
 }
@@ -956,7 +957,8 @@ function validateStepGraph(
         visiting.add(stepId)
         const step = stepById.get(stepId)
 
-        for (const dependencyId of step?.dependsOn ?? []) visit(dependencyId, [...chain, stepId])
+        for (const dependencyId of step?.dependsOn ?? [])
+            visit(dependencyId, [...chain, stepId])
 
         visiting.delete(stepId)
         visited.add(stepId)

--- a/packages/lixpi/prosemirror/src/shared/generated-media-turn-projection.ts
+++ b/packages/lixpi/prosemirror/src/shared/generated-media-turn-projection.ts
@@ -424,7 +424,8 @@ const collectMatchingGeneratedMediaLineageIds = (
             addLineageId(lineageIds.branchLineNodeIds, node.attrs?.branchLineNodeId)
         }
 
-        for (const child of node.content ?? []) visit(child)
+        for (const child of node.content ?? [])
+            visit(child)
     }
 
     visit(container)
@@ -641,7 +642,8 @@ export const getGeneratedMediaProgressFromThreadContent = (
         if (progress)
             return
 
-        for (const child of node.content ?? []) visit(child)
+        for (const child of node.content ?? [])
+            visit(child)
     }
     visit(root)
 
@@ -958,7 +960,8 @@ const relocateLineageEventsToResolverAudit = (node: ProseMirrorJsonNode): void =
         node.content = [...rest.slice(0, insertAt), ...lineageEvents, ...rest.slice(insertAt)]
     }
 
-    for (const child of node.content) relocateLineageEventsToResolverAudit(child)
+    for (const child of node.content)
+        relocateLineageEventsToResolverAudit(child)
 }
 
 const cloneResponseForProjection = (

--- a/packages/lixpi/prosemirror/src/shared/thread-doc.ts
+++ b/packages/lixpi/prosemirror/src/shared/thread-doc.ts
@@ -85,7 +85,8 @@ export const collectProseMirrorPromptReferences = (node: ProseMirrorJsonNode | n
         if (attrs)
             references.push(attrs)
 
-        for (const child of candidate.content ?? []) visit(child)
+        for (const child of candidate.content ?? [])
+            visit(child)
     }
     visit(node)
 

--- a/packages/lixpi/ui-kit/src/components/blockCardTilesList/blockCardTilesList/blockCardTilesList.ts
+++ b/packages/lixpi/ui-kit/src/components/blockCardTilesList/blockCardTilesList/blockCardTilesList.ts
@@ -42,7 +42,8 @@ class BlockCardTilesList implements BlockCardTilesListInstance {
     }
 
     setItems(items: BlockCardTileItem[]): void {
-        for (const tile of this.tiles.values()) tile.destroy()
+        for (const tile of this.tiles.values())
+            tile.destroy()
 
         this.tiles.clear()
         this.itemsHost.replaceChildren()
@@ -60,7 +61,8 @@ class BlockCardTilesList implements BlockCardTilesListInstance {
     }
 
     destroy(): void {
-        for (const tile of this.tiles.values()) tile.destroy()
+        for (const tile of this.tiles.values())
+            tile.destroy()
 
         this.tiles.clear()
         this.element.remove()

--- a/packages/lixpi/ui-kit/src/components/sidePanel/sidePanel.ts
+++ b/packages/lixpi/ui-kit/src/components/sidePanel/sidePanel.ts
@@ -395,7 +395,8 @@ class SidePanel implements SidePanelInstance {
     private emit = (width: number): void => {
         this.config.onResize?.(width)
 
-        for (const listener of this.listeners) listener(width)
+        for (const listener of this.listeners)
+            listener(width)
     }
 
     private persist = (): void => void this.config.persistState?.(
@@ -862,7 +863,8 @@ class SidePanel implements SidePanelInstance {
     }
 
     private forceSlideStartFrame = (targets: SlideTarget[]): void => {
-        for (const target of targets) void target.element.offsetWidth
+        for (const target of targets)
+            void target.element.offsetWidth
     }
 
     private nextAnimationFrame = (): Promise<void> => new Promise(resolve => void requestAnimationFrame(() => resolve()))
@@ -966,7 +968,8 @@ class SidePanel implements SidePanelInstance {
                     finish()
             }
             const finish = (): void => {
-                for (const target of targets) target.removeEventListener('transitionend', handleTransitionEnd)
+                for (const target of targets)
+                    target.removeEventListener('transitionend', handleTransitionEnd)
 
                 window.clearTimeout(timeoutId)
 
@@ -979,7 +982,8 @@ class SidePanel implements SidePanelInstance {
 
             this.finishSlideWait = finish
 
-            for (const target of targets) target.addEventListener('transitionend', handleTransitionEnd)
+            for (const target of targets)
+                target.addEventListener('transitionend', handleTransitionEnd)
         })
 
     private setAnimatedPanel = (panelElement: HTMLElement | null): void => {

--- a/packages/lixpi/ui-kit/src/components/slidingDropdown/slidingDropdown.ts
+++ b/packages/lixpi/ui-kit/src/components/slidingDropdown/slidingDropdown.ts
@@ -1353,7 +1353,8 @@ class SlidingDropdown<Value extends string = string> implements SlidingDropdownI
         if (this.destroyed)
             return
 
-        for (const view of this.optionViews) this.renderOptionView(view)
+        for (const view of this.optionViews)
+            this.renderOptionView(view)
     }
 
     private renderIndicator(y: number): void {
@@ -2463,7 +2464,8 @@ class SlidingDropdown<Value extends string = string> implements SlidingDropdownI
             )
         }
 
-        for (const view of this.optionViews) view.customRenderer?.destroy?.()
+        for (const view of this.optionViews)
+            view.customRenderer?.destroy?.()
 
         this.restoreSvgPortal()
         this.group.remove()

--- a/packages/lixpi/ui-kit/src/components/slidingSwitch/slidingSwitch.ts
+++ b/packages/lixpi/ui-kit/src/components/slidingSwitch/slidingSwitch.ts
@@ -609,7 +609,8 @@ class SlidingSwitch<Value extends string = string> implements SlidingSwitchInsta
     }
 
     private synchronizeOptionDomOrder(): void {
-        for (const view of this.optionViews) view.group.raise()
+        for (const view of this.optionViews)
+            view.group.raise()
     }
 
     private completeReshuffleAnimation(): void {
@@ -1123,7 +1124,8 @@ class SlidingSwitch<Value extends string = string> implements SlidingSwitchInsta
             this.indicatorAnimationTargetX = targetX
 
         if (!this.reshuffleAnimationActive) {
-            for (const view of this.optionViews) this.renderOptionView(view)
+            for (const view of this.optionViews)
+                this.renderOptionView(view)
         }
     }
 
@@ -1237,7 +1239,8 @@ class SlidingSwitch<Value extends string = string> implements SlidingSwitchInsta
         this.resizeObserver?.disconnect()
         this.observedResizeTargets.clear()
 
-        for (const view of this.optionViews) view.customRenderer?.destroy?.()
+        for (const view of this.optionViews)
+            view.customRenderer?.destroy?.()
 
         this.group.remove()
     }

--- a/packages/lixpi/ui-primitives/src/gradients/shiftingGradientRenderer.ts
+++ b/packages/lixpi/ui-primitives/src/gradients/shiftingGradientRenderer.ts
@@ -474,7 +474,8 @@ export class ShiftingGradientBackground {
                 if (this.destroyed)
                     return
 
-                for (const entry of entries) this.renderer.setVisibility(this.canvas, entry.isIntersecting)
+                for (const entry of entries)
+                    this.renderer.setVisibility(this.canvas, entry.isIntersecting)
             },
             { threshold: 0 },
         )

--- a/packages/lixpi/ui-primitives/src/svg/animatedSvgIcon.ts
+++ b/packages/lixpi/ui-primitives/src/svg/animatedSvgIcon.ts
@@ -296,7 +296,8 @@ export class AnimatedSvgIcon<State extends string> implements AnimatedSvgIconIns
 
         this.destroyed = true
 
-        for (const runtime of this.parts) runtime.group.interrupt(this.transitionNamespace)
+        for (const runtime of this.parts)
+            runtime.group.interrupt(this.transitionNamespace)
 
         this.element.remove()
     }

--- a/services/ai-model-registry/src/client/app.ts
+++ b/services/ai-model-registry/src/client/app.ts
@@ -389,7 +389,8 @@ class ParamPicker {
 
         for (const provider of this.#catalog.providers) {
             for (const group of provider.groups) {
-                for (const model of group.supportedModels ?? []) models.add(model)
+                for (const model of group.supportedModels ?? [])
+                    models.add(model)
             }
         }
 

--- a/services/ai-model-registry/src/server.ts
+++ b/services/ai-model-registry/src/server.ts
@@ -145,9 +145,11 @@ class AiModelRegistryServer {
             const categories = new Set<string>()
 
             for (const param of group.parameters) {
-                for (const model of param.supportedModels) models.add(model)
+                for (const model of param.supportedModels)
+                    models.add(model)
 
-                for (const api of param.supportedApis) apis.add(api)
+                for (const api of param.supportedApis)
+                    apis.add(api)
 
                 categories.add(param.category)
             }
@@ -425,7 +427,8 @@ class AiModelRegistryServer {
             for (const {
                 path,
                 record,
-            } of pending) await this.tree.writeParam(path, record)
+            } of pending)
+                await this.tree.writeParam(path, record)
 
             AiModelRegistryServer.sendJson(
                 res,
@@ -599,12 +602,14 @@ class AiModelRegistryServer {
             for (const {
                 path,
                 record,
-            } of pendingParams) await this.tree.writeParam(path, record)
+            } of pendingParams)
+                await this.tree.writeParam(path, record)
 
             for (const {
                 path,
                 meta,
-            } of pendingGroups) await this.tree.writeGroupMeta(path, meta)
+            } of pendingGroups)
+                await this.tree.writeGroupMeta(path, meta)
 
             AiModelRegistryServer.sendJson(
                 res,

--- a/services/api/src/NATS/subscriptions/ai-interaction-subjects.ts
+++ b/services/api/src/NATS/subscriptions/ai-interaction-subjects.ts
@@ -209,7 +209,8 @@ const findSealedMediaReplayTrace = (
         )
             traces.push(candidate as SealedMediaReplayTrace)
 
-        for (const child of node.content ?? []) visit(child)
+        for (const child of node.content ?? [])
+            visit(child)
     }
     visit(root)
     const exactTrace = traces.find(trace => {
@@ -919,7 +920,8 @@ const mergePromptReferenceMediaCandidates = ({
 
     const candidatesById = new Map<string, MediaBranchCandidateSnapshot['candidates'][number]>()
 
-    for (const candidate of snapshot?.candidates ?? []) candidatesById.set(candidate.candidateId, candidate)
+    for (const candidate of snapshot?.candidates ?? [])
+        candidatesById.set(candidate.candidateId, candidate)
 
     for (const candidate of candidates) {
         const existing = candidatesById.get(candidate.candidateId)

--- a/services/api/src/NATS/subscriptions/asset-subjects.ts
+++ b/services/api/src/NATS/subscriptions/asset-subjects.ts
@@ -395,7 +395,8 @@ export const assetSubjects = [
                 primaryCategory: data.primaryCategory as AssetPrimaryCategory | undefined,
             })
 
-            for (const item of result.items) rememberAuthorizedAssetEvent(requester.userId, item.assetId)
+            for (const item of result.items)
+                rememberAuthorizedAssetEvent(requester.userId, item.assetId)
 
             return result
         },

--- a/services/api/src/debug-tools/convert-workspace-export-to-assets.ts
+++ b/services/api/src/debug-tools/convert-workspace-export-to-assets.ts
@@ -130,15 +130,17 @@ const files = new Map<string, LegacyFile>(
 const canvasNodes = oldManifest.workspace.canvasState.nodes ?? []
 const renditionLinkFields = ['posterFileId', 'frameFileId', 'canonicalFileId', 'previewFileId', 'thumbnailFileId'] as const
 
-for (const document of oldManifest.documents ?? []) legacyIdToAssetId.set(
-    document.documentId,
-    uuid(),
-)
+for (const document of oldManifest.documents ?? [])
+    legacyIdToAssetId.set(
+        document.documentId,
+        uuid(),
+    )
 
-for (const thread of oldManifest.aiChatThreads ?? []) legacyIdToAssetId.set(
-    thread.threadId,
-    uuid(),
-)
+for (const thread of oldManifest.aiChatThreads ?? [])
+    legacyIdToAssetId.set(
+        thread.threadId,
+        uuid(),
+    )
 
 const rootFileIds = new Set<string>()
 const relatedFileIdsByRoot = new Map<string, Set<string>>()
@@ -824,7 +826,8 @@ outputZip.addFile(
     ),
 )
 
-for (const [blobHash, bytes] of blobBytes) outputZip.addFile(`blobs/${blobHash}`, bytes)
+for (const [blobHash, bytes] of blobBytes)
+    outputZip.addFile(`blobs/${blobHash}`, bytes)
 
 await writeFile(
     outputPath,

--- a/services/api/src/llm/graph/media-branch-resolver.ts
+++ b/services/api/src/llm/graph/media-branch-resolver.ts
@@ -993,9 +993,10 @@ export const resolveMediaBranch = async (
                     urlByCandidateId.get(resolution.targetCandidateId),
                 )
 
-            for (const candidateId of resolution.referenceCandidateIds) pushFrame(
-                urlByCandidateId.get(candidateId),
-            )
+            for (const candidateId of resolution.referenceCandidateIds)
+                pushFrame(
+                    urlByCandidateId.get(candidateId),
+                )
 
             videoFirstFrameImage = orderedFrames[0]
             videoReferenceImages = orderedFrames.slice(1, 2)

--- a/services/api/src/llm/graph/media-branch-snapshot.ts
+++ b/services/api/src/llm/graph/media-branch-snapshot.ts
@@ -91,7 +91,8 @@ export const deduplicateMediaBranchSnapshotCandidatesByAsset = (snapshot: MediaB
             snapshot.resolvedTargetCandidateId,
         )
 
-        for (const candidate of candidateGroup) candidateIdAliases.set(candidate.candidateId, canonical.candidateId)
+        for (const candidate of candidateGroup)
+            candidateIdAliases.set(candidate.candidateId, canonical.candidateId)
 
         return canonical
     })

--- a/services/api/src/llm/media-reference/media-reference-compiler.ts
+++ b/services/api/src/llm/media-reference/media-reference-compiler.ts
@@ -150,7 +150,8 @@ export const segmentMediaPrompt = (node: ProseMirrorJsonNode): MediaPromptSegmen
             return
         }
 
-        for (const child of candidate.content ?? []) visit(child)
+        for (const child of candidate.content ?? [])
+            visit(child)
     }
     visit(node)
 

--- a/services/api/src/llm/media-reference/media-reference-matcher.ts
+++ b/services/api/src/llm/media-reference/media-reference-matcher.ts
@@ -202,9 +202,10 @@ const trigrams = (value: string): Set<string> => {
     const padded = `  ${value}  `
     const result = new Set<string>()
 
-    for (let index = 0; index <= padded.length - 3; index++) result.add(
-        padded.slice(index, index + 3),
-    )
+    for (let index = 0; index <= padded.length - 3; index++)
+        result.add(
+            padded.slice(index, index + 3),
+        )
 
     return result
 }

--- a/services/api/src/llm/providers/google-provider.ts
+++ b/services/api/src/llm/providers/google-provider.ts
@@ -1476,7 +1476,8 @@ function mergeGoogleUsageMetadata(
         ...second,
     }
 
-    for (const key of numericKeys) merged[key] = (first[key] ?? 0) + (second[key] ?? 0)
+    for (const key of numericKeys)
+        merged[key] = (first[key] ?? 0) + (second[key] ?? 0)
 
     return merged
 }

--- a/services/api/src/routes/workspace-export-routes.ts
+++ b/services/api/src/routes/workspace-export-routes.ts
@@ -326,7 +326,8 @@ const buildPortableWorkspaceReferences = async ({
                 if (matchingSurfaces.length === 0)
                     throw new Error(`EMBEDDED_ASSET_REFERENCE_MISSING:${hostAsset.assetId}:${embeddedAssetId}`)
 
-                for (const surfaceId of matchingSurfaces) addSurface(embeddedAssetId, surfaceId)
+                for (const surfaceId of matchingSurfaces)
+                    addSurface(embeddedAssetId, surfaceId)
             }
         }
     }
@@ -1040,9 +1041,11 @@ router.get(
             const requester = await getAssetRequesterContext(req.user.userId)
             const initialAssetIds = getCanvasAssetIds(req.workspace.canvasState)
 
-            for (const assetId of await getWorkspaceCatalogAssetIds(req.params.workspaceId)) initialAssetIds.add(assetId)
+            for (const assetId of await getWorkspaceCatalogAssetIds(req.params.workspaceId))
+                initialAssetIds.add(assetId)
 
-            for (const assetId of await getWorkspaceReferenceAssetIds(req.params.workspaceId)) initialAssetIds.add(assetId)
+            for (const assetId of await getWorkspaceReferenceAssetIds(req.params.workspaceId))
+                initialAssetIds.add(assetId)
 
             const assets = await collectExportAssets({
                 initialAssetIds,

--- a/services/api/src/services/asset-canvas-projection.ts
+++ b/services/api/src/services/asset-canvas-projection.ts
@@ -2159,7 +2159,8 @@ export const detachReviewedGeneratedOutputsFromCanvas = ({
                 'branchLineNodeId',
                 'lineageParentNodeId',
             ]
-        ) delete provenanceLocator[field]
+        )
+            delete provenanceLocator[field]
 
         if (
             candidate.type === 'image'

--- a/services/api/src/services/asset-document-service.ts
+++ b/services/api/src/services/asset-document-service.ts
@@ -404,7 +404,8 @@ export const assertAssetBackedMediaNodes = (node: unknown): void => {
     }
 
     if (Array.isArray(record.content)) {
-        for (const child of record.content) assertAssetBackedMediaNodes(child)
+        for (const child of record.content)
+            assertAssetBackedMediaNodes(child)
     }
 }
 

--- a/services/api/src/services/prompt-reference-resolver.ts
+++ b/services/api/src/services/prompt-reference-resolver.ts
@@ -92,7 +92,8 @@ export const extractLatestUserPromptReferences = (
             }
         }
 
-        for (const child of node.content ?? []) visit(child)
+        for (const child of node.content ?? [])
+            visit(child)
     }
     visit(latestUserMessage)
 

--- a/services/api/src/services/prosemirror-asset-references.ts
+++ b/services/api/src/services/prosemirror-asset-references.ts
@@ -29,11 +29,12 @@ const collectAssetIds = (
     if (!Array.isArray(record.content))
         return
 
-    for (const child of record.content) collectAssetIds(
-        child,
-        includePromptReferences,
-        assetIds,
-    )
+    for (const child of record.content)
+        collectAssetIds(
+            child,
+            includePromptReferences,
+            assetIds,
+        )
 }
 
 export const collectReferencedAssetIds = (node: unknown): Set<string> => {

--- a/services/api/src/services/prosemirror-text.ts
+++ b/services/api/src/services/prosemirror-text.ts
@@ -22,7 +22,8 @@ export const collectDocumentText = (doc: object): string => {
         )
             parts.push('\n')
 
-        for (const child of node.content ?? []) visit(child)
+        for (const child of node.content ?? [])
+            visit(child)
     }
     visit(root)
 

--- a/services/nex/workloads/character-fidelity/scorer.ts
+++ b/services/nex/workloads/character-fidelity/scorer.ts
@@ -630,7 +630,8 @@ const cosineSimilarity = (
 
     let score = 0
 
-    for (let index = 0; index < left.length; index += 1) score += left[index]! * right[index]!
+    for (let index = 0; index < left.length; index += 1)
+        score += left[index]! * right[index]!
 
     return Math.max(
         -1,

--- a/services/typescript-quality-runner/import-specifier-order.ts
+++ b/services/typescript-quality-runner/import-specifier-order.ts
@@ -92,9 +92,10 @@ const collectTypeScriptFiles = async (inputPaths: string[]): Promise<CollectedTy
         }
     }
 
-    for (const inputPath of inputPaths) await visit(
-        resolve(inputPath),
-    )
+    for (const inputPath of inputPaths)
+        await visit(
+            resolve(inputPath),
+        )
 
     return {
         files: files.sort(),
@@ -377,7 +378,8 @@ const runCli = async (): Promise<void> => {
     } = await collectTypeScriptFiles(inputPaths)
 
     if (prohibitedFiles.length > 0) {
-        for (const file of prohibitedFiles) err(`${file}: JSX source files are prohibited; use a .ts module and the repository DOM APIs`)
+        for (const file of prohibitedFiles)
+            err(`${file}: JSX source files are prohibited; use a .ts module and the repository DOM APIs`)
 
         process.exit(1)
     }
@@ -407,9 +409,8 @@ const runCli = async (): Promise<void> => {
             continue
         }
 
-        if (mode === 'check') for (const line of violations) err(
-            `${file}:${line}: named imports and exports must use the repository value/type layout`,
-        )
+        if (mode === 'check') for (const line of violations)
+            err(`${file}:${line}: named imports and exports must use the repository value/type layout`)
     }
 
     if (mode === 'fix') {

--- a/services/typescript-quality-runner/lixpi-oxlint-plugin.ts
+++ b/services/typescript-quality-runner/lixpi-oxlint-plugin.ts
@@ -22,8 +22,9 @@ const collectIdentifierNames = (
             continue
 
         if (Array.isArray(value)) {
-            for (const child of value) if (isAstNode(child))
-                collectIdentifierNames(child, names)
+            for (const child of value)
+                if (isAstNode(child))
+                    collectIdentifierNames(child, names)
         } else if (isAstNode(value))
             collectIdentifierNames(value, names)
     }
@@ -1047,9 +1048,10 @@ const getSeparatedVariableDeclarationText = (
                 && comment.loc.start.line === declaration.loc.end.line,
         )
 
-        for (const comment of leadingComments) declarationLines.push(
-            sourceCode.getText(comment),
-        )
+        for (const comment of leadingComments)
+            declarationLines.push(
+                sourceCode.getText(comment),
+            )
 
         const trailingText = trailingComments.length > 0
             ? ` ${trailingComments.map(comment => sourceCode.getText(comment)).join(' ')}`
@@ -1664,12 +1666,13 @@ const preferSeparatedStatements = defineRule({
             }
         }
         const checkSwitchCases = (node): void => {
-            for (let index = 1; index < node.cases.length; index++) reportSiblingGap(
-                node.cases[index - 1],
-                node.cases[index],
-                false,
-                'joinCases',
-            )
+            for (let index = 1; index < node.cases.length; index++)
+                reportSiblingGap(
+                    node.cases[index - 1],
+                    node.cases[index],
+                    false,
+                    'joinCases',
+                )
         }
 
         return {

--- a/services/typescript-quality-runner/source-extension-runner.ts
+++ b/services/typescript-quality-runner/source-extension-runner.ts
@@ -115,9 +115,10 @@ const collectSourceFiles = async (inputPaths: string[]): Promise<SourceFiles> =>
         }
     }
 
-    for (const inputPath of inputPaths) await visit(
-        resolve(inputPath),
-    )
+    for (const inputPath of inputPaths)
+        await visit(
+            resolve(inputPath),
+        )
 
     return {
         importers: importers.sort(),
@@ -202,8 +203,9 @@ const getModuleSpecifierNodes = (
                 continue
 
             if (Array.isArray(value)) {
-                for (const child of value) if (isAstNode(child))
-                    visit(child)
+                for (const child of value)
+                    if (isAstNode(child))
+                        visit(child)
             } else if (isAstNode(value))
                 visit(value)
         }
@@ -220,7 +222,8 @@ const applySourceReplacements = (
 ): string => {
     let output = source
 
-    for (const replacement of replacements.sort((left, right) => right.start - left.start)) output = `${output.slice(0, replacement.start)}${replacement.value}${output.slice(replacement.end)}`
+    for (const replacement of replacements.sort((left, right) => right.start - left.start))
+        output = `${output.slice(0, replacement.start)}${replacement.value}${output.slice(replacement.end)}`
 
     return output
 }
@@ -286,7 +289,8 @@ const {
 } = await collectSourceFiles(inputPaths)
 
 if (prohibitedFiles.length > 0) {
-    for (const file of prohibitedFiles) err(`${file}: JSX source files are prohibited; use a .ts module and the repository DOM APIs`)
+    for (const file of prohibitedFiles)
+        err(`${file}: JSX source files are prohibited; use a .ts module and the repository DOM APIs`)
 
     process.exit(1)
 }
@@ -295,7 +299,8 @@ if (mode === 'check') {
     if (javaScriptFiles.length === 0)
         process.exit(0)
 
-    for (const file of javaScriptFiles) err(`${file}: JavaScript source files are prohibited; use a .ts extension`)
+    for (const file of javaScriptFiles)
+        err(`${file}: JavaScript source files are prohibited; use a .ts extension`)
 
     process.exit(1)
 }
@@ -315,7 +320,8 @@ for (const target of renamedFiles.values()) {
     }
 }
 
-for (const [source, target] of renamedFiles) await rename(source, target)
+for (const [source, target] of renamedFiles)
+    await rename(source, target)
 
 let updatedImporterCount = 0
 

--- a/services/typescript-quality-runner/stylelint-lixpi-plugin.ts
+++ b/services/typescript-quality-runner/stylelint-lixpi-plugin.ts
@@ -103,8 +103,9 @@ const isTransitionCustomProperty = (property: string): boolean => {
     if (nameEnd <= 2)
         return false
 
-    for (let index = 2; index < nameEnd; index++) if (!isLowercaseIdentifierCharacter(property[index]))
-        return false
+    for (let index = 2; index < nameEnd; index++)
+        if (!isLowercaseIdentifierCharacter(property[index]))
+            return false
 
     return true
 }

--- a/services/typescript-quality-runner/stylelint-runner.ts
+++ b/services/typescript-quality-runner/stylelint-runner.ts
@@ -68,7 +68,8 @@ if (
 
 const stylesheetPaths: string[] = []
 
-for (const inputPath of process.argv.slice(3)) await collectStylesheetPaths(inputPath, stylesheetPaths)
+for (const inputPath of process.argv.slice(3))
+    await collectStylesheetPaths(inputPath, stylesheetPaths)
 
 if (stylesheetPaths.length === 0)
     process.exit(0)

--- a/services/typescript-quality-runner/typescript-format-runner.ts
+++ b/services/typescript-quality-runner/typescript-format-runner.ts
@@ -234,9 +234,10 @@ const collectFormattingFiles = async (inputPaths: string[]): Promise<FormattingF
         }
     }
 
-    for (const inputPath of inputPaths) await visit(
-        resolve(inputPath),
-    )
+    for (const inputPath of inputPaths)
+        await visit(
+            resolve(inputPath),
+        )
 
     return {
         files: files.sort(),
@@ -653,14 +654,15 @@ const collectTypeScriptLayouts = (
                 )
 
             if (Array.isArray(value)) {
-                for (const child of value) if (isAstNode(child))
-                    visit(
-                        child,
-                        node,
-                        parent,
-                        key,
-                        childInsideCondition,
-                    )
+                for (const child of value)
+                    if (isAstNode(child))
+                        visit(
+                            child,
+                            node,
+                            parent,
+                            key,
+                            childInsideCondition,
+                        )
             } else if (isAstNode(value))
                 visit(
                     value,
@@ -779,10 +781,8 @@ const preserveExpandedTypeScriptLayouts = (
 
     let output = formatted
 
-    for (const replacement of nonOverlappingReplacements.sort((left, right) => right.start - left.start)) output = `${output.slice(
-        0,
-        replacement.start,
-    )}${replacement.text}${output.slice(replacement.end)}`
+    for (const replacement of nonOverlappingReplacements.sort((left, right) => right.start - left.start))
+        output = `${output.slice(0, replacement.start)}${replacement.text}${output.slice(replacement.end)}`
 
     return output
 }
@@ -1205,12 +1205,13 @@ const canonicalizeDelimitedListsOnce = (
                 continue
 
             if (Array.isArray(value)) {
-                for (const child of value) if (isAstNode(child))
-                    visit(
-                        child,
-                        ownStatementStart,
-                        node,
-                    )
+                for (const child of value)
+                    if (isAstNode(child))
+                        visit(
+                            child,
+                            ownStatementStart,
+                            node,
+                        )
             } else if (isAstNode(value))
                 visit(
                     value,
@@ -1240,10 +1241,8 @@ const canonicalizeDelimitedListsOnce = (
 
     let output = source
 
-    for (const replacement of nonOverlappingReplacements.sort((left, right) => right.start - left.start)) output = `${output.slice(
-        0,
-        replacement.start,
-    )}${replacement.text}${output.slice(replacement.end)}`
+    for (const replacement of nonOverlappingReplacements.sort((left, right) => right.start - left.start))
+        output = `${output.slice(0, replacement.start)}${replacement.text}${output.slice(replacement.end)}`
 
     return output
 }
@@ -1327,8 +1326,9 @@ const collectHtmlTemplateQuasis = (
                 continue
 
             if (Array.isArray(value)) {
-                for (const child of value) if (isAstNode(child))
-                    visit(child)
+                for (const child of value)
+                    if (isAstNode(child))
+                        visit(child)
             } else if (isAstNode(value))
                 visit(value)
         }
@@ -1409,7 +1409,8 @@ const applyHtmlTemplateFormatting = (
     )
     let output = formatted
 
-    for (const replacement of replacements.sort((left, right) => right.start - left.start)) output = `${output.slice(0, replacement.start)}${replacement.text}${output.slice(replacement.end)}`
+    for (const replacement of replacements.sort((left, right) => right.start - left.start))
+        output = `${output.slice(0, replacement.start)}${replacement.text}${output.slice(replacement.end)}`
 
     return output
 }
@@ -1464,7 +1465,8 @@ const collectHtmlTemplateContents = (
             if (rawRanges.every(range => range != null)) {
                 const interpolationRanges: Array<[number, number]> = []
 
-                for (let index = 0; index < rawRanges.length - 1; index++) interpolationRanges.push([rawRanges[index]![1], rawRanges[index + 1]![0]])
+                for (let index = 0; index < rawRanges.length - 1; index++)
+                    interpolationRanges.push([rawRanges[index]![1], rawRanges[index + 1]![0]])
 
                 contents.push({
                     start: templateRange[0] + 1,
@@ -1480,8 +1482,9 @@ const collectHtmlTemplateContents = (
                 continue
 
             if (Array.isArray(value)) {
-                for (const child of value) if (isAstNode(child))
-                    visit(child)
+                for (const child of value)
+                    if (isAstNode(child))
+                        visit(child)
             } else if (isAstNode(value))
                 visit(value)
         }
@@ -1498,9 +1501,12 @@ const maskHtmlInterpolations = (
 ): string => {
     const characters: string[] = []
 
-    for (let offset = content.start; offset < content.end; offset++) characters.push(source[offset]!)
+    for (let offset = content.start; offset < content.end; offset++)
+        characters.push(source[offset]!)
 
-    for (const range of content.interpolationRanges) for (let offset = range[0]; offset < range[1]; offset++) characters[offset - content.start] = 'x'
+    for (const range of content.interpolationRanges)
+        for (let offset = range[0]; offset < range[1]; offset++)
+            characters[offset - content.start] = 'x'
 
     return characters.join('')
 }
@@ -1579,13 +1585,15 @@ const collectExpandedHtmlStartTags = (
             }
         }
 
-        for (const child of node.childNodes ?? []) visit(child, depth + 1)
+        for (const child of node.childNodes ?? [])
+            visit(child, depth + 1)
 
         if (node.content)
             visit(node.content, depth + 1)
     }
 
-    for (const child of root.childNodes ?? []) visit(child, 0)
+    for (const child of root.childNodes ?? [])
+        visit(child, 0)
 
     return replacements
 }
@@ -1596,7 +1604,8 @@ const applyHtmlAttributeReplacements = (
 ): string => {
     let output = source
 
-    for (const replacement of replacements.sort((left, right) => right.start - left.start)) output = `${output.slice(0, replacement.start)}${replacement.text}${output.slice(replacement.end)}`
+    for (const replacement of replacements.sort((left, right) => right.start - left.start))
+        output = `${output.slice(0, replacement.start)}${replacement.text}${output.slice(replacement.end)}`
 
     return output
 }
@@ -1786,8 +1795,9 @@ const canonicalizeAssignmentBoundaries = (
                 continue
 
             if (Array.isArray(childValue)) {
-                for (const child of childValue) if (isAstNode(child))
-                    visit(child)
+                for (const child of childValue)
+                    if (isAstNode(child))
+                        visit(child)
             } else if (isAstNode(childValue))
                 visit(childValue)
         }
@@ -1796,10 +1806,8 @@ const canonicalizeAssignmentBoundaries = (
     visit(parseResult.program as AstNode)
     let output = source
 
-    for (const replacement of [...replacements, ...dedentedLineStarts.values()].sort((left, right) => right.start - left.start)) output = `${output.slice(
-        0,
-        replacement.start,
-    )}${replacement.text}${output.slice(replacement.end)}`
+    for (const replacement of [...replacements, ...dedentedLineStarts.values()].sort((left, right) => right.start - left.start))
+        output = `${output.slice(0, replacement.start)}${replacement.text}${output.slice(replacement.end)}`
 
     return output
 }
@@ -1884,8 +1892,9 @@ const canonicalizeArrowParameters = (
                 continue
 
             if (Array.isArray(value)) {
-                for (const child of value) if (isAstNode(child))
-                    visit(child)
+                for (const child of value)
+                    if (isAstNode(child))
+                        visit(child)
             } else if (isAstNode(value))
                 visit(value)
         }
@@ -1894,7 +1903,8 @@ const canonicalizeArrowParameters = (
     visit(parseResult.program as AstNode)
     let output = source
 
-    for (const replacement of replacements.sort((left, right) => right.start - left.start)) output = `${output.slice(0, replacement.start)}${replacement.text}${output.slice(replacement.end)}`
+    for (const replacement of replacements.sort((left, right) => right.start - left.start))
+        output = `${output.slice(0, replacement.start)}${replacement.text}${output.slice(replacement.end)}`
 
     return output
 }
@@ -1951,8 +1961,9 @@ const canonicalizeExpressionArrowBodies = (
                 continue
 
             if (Array.isArray(value)) {
-                for (const child of value) if (isAstNode(child))
-                    visit(child)
+                for (const child of value)
+                    if (isAstNode(child))
+                        visit(child)
             } else if (isAstNode(value))
                 visit(value)
         }
@@ -1961,7 +1972,8 @@ const canonicalizeExpressionArrowBodies = (
     visit(parseResult.program as AstNode)
     let output = source
 
-    for (const replacement of replacements.sort((left, right) => right.start - left.start)) output = `${output.slice(0, replacement.start)}${replacement.text}${output.slice(replacement.end)}`
+    for (const replacement of replacements.sort((left, right) => right.start - left.start))
+        output = `${output.slice(0, replacement.start)}${replacement.text}${output.slice(replacement.end)}`
 
     return output
 }
@@ -2144,12 +2156,13 @@ const canonicalizeIteratorChainsOnce = (
                 continue
 
             if (Array.isArray(value)) {
-                for (const child of value) if (isAstNode(child))
-                    visit(
-                        child,
-                        node,
-                        parent,
-                    )
+                for (const child of value)
+                    if (isAstNode(child))
+                        visit(
+                            child,
+                            node,
+                            parent,
+                        )
             } else if (isAstNode(value))
                 visit(
                     value,
@@ -2162,7 +2175,8 @@ const canonicalizeIteratorChainsOnce = (
     visit(parseResult.program as AstNode)
     let output = source
 
-    for (const replacement of replacements.sort((left, right) => right.start - left.start)) output = `${output.slice(0, replacement.start)}${replacement.text}${output.slice(replacement.end)}`
+    for (const replacement of replacements.sort((left, right) => right.start - left.start))
+        output = `${output.slice(0, replacement.start)}${replacement.text}${output.slice(replacement.end)}`
 
     return output
 }
@@ -2271,8 +2285,9 @@ const canonicalizeHtmlTemplateBoundaries = (
                 continue
 
             if (Array.isArray(value)) {
-                for (const child of value) if (isAstNode(child))
-                    visit(child)
+                for (const child of value)
+                    if (isAstNode(child))
+                        visit(child)
             } else if (isAstNode(value))
                 visit(value)
         }
@@ -2281,7 +2296,8 @@ const canonicalizeHtmlTemplateBoundaries = (
     visit(parseResult.program as AstNode)
     let output = source
 
-    for (const replacement of replacements.sort((left, right) => right.start - left.start)) output = `${output.slice(0, replacement.start)}${replacement.text}${output.slice(replacement.end)}`
+    for (const replacement of replacements.sort((left, right) => right.start - left.start))
+        output = `${output.slice(0, replacement.start)}${replacement.text}${output.slice(replacement.end)}`
 
     return output
 }
@@ -2418,8 +2434,9 @@ const canonicalizeNestedConditionalExpressions = (
                 continue
 
             if (Array.isArray(value)) {
-                for (const child of value) if (isAstNode(child))
-                    visit(child)
+                for (const child of value)
+                    if (isAstNode(child))
+                        visit(child)
             } else if (isAstNode(value))
                 visit(value)
         }
@@ -2428,7 +2445,8 @@ const canonicalizeNestedConditionalExpressions = (
     visit(parseResult.program as AstNode)
     let output = source
 
-    for (const replacement of replacements.sort((left, right) => right.start - left.start)) output = `${output.slice(0, replacement.start)}${replacement.text}${output.slice(replacement.end)}`
+    for (const replacement of replacements.sort((left, right) => right.start - left.start))
+        output = `${output.slice(0, replacement.start)}${replacement.text}${output.slice(replacement.end)}`
 
     return output
 }
@@ -2711,8 +2729,9 @@ const canonicalizeAssignedLogicalExpressions = (
                 continue
 
             if (Array.isArray(childValue)) {
-                for (const child of childValue) if (isAstNode(child))
-                    visit(child)
+                for (const child of childValue)
+                    if (isAstNode(child))
+                        visit(child)
             } else if (isAstNode(childValue))
                 visit(childValue)
         }
@@ -2721,7 +2740,8 @@ const canonicalizeAssignedLogicalExpressions = (
     visit(parseResult.program as AstNode)
     let output = source
 
-    for (const replacement of replacements.sort((left, right) => right.start - left.start)) output = `${output.slice(0, replacement.start)}${replacement.text}${output.slice(replacement.end)}`
+    for (const replacement of replacements.sort((left, right) => right.start - left.start))
+        output = `${output.slice(0, replacement.start)}${replacement.text}${output.slice(replacement.end)}`
 
     return output
 }
@@ -2830,11 +2850,12 @@ const canonicalizeStatementSpacing = (
         ) {
             const cases = node.cases.filter(isAstNode)
 
-            for (let index = 1; index < cases.length; index++) addSiblingGapReplacement(
-                cases[index - 1]!,
-                cases[index]!,
-                false,
-            )
+            for (let index = 1; index < cases.length; index++)
+                addSiblingGapReplacement(
+                    cases[index - 1]!,
+                    cases[index]!,
+                    false,
+                )
         }
 
         const statements = getStatementList(node)
@@ -2863,8 +2884,9 @@ const canonicalizeStatementSpacing = (
                 continue
 
             if (Array.isArray(value)) {
-                for (const child of value) if (isAstNode(child))
-                    visit(child)
+                for (const child of value)
+                    if (isAstNode(child))
+                        visit(child)
             } else if (isAstNode(value))
                 visit(value)
         }
@@ -2873,7 +2895,8 @@ const canonicalizeStatementSpacing = (
     visit(parseResult.program as AstNode)
     let output = source
 
-    for (const replacement of replacements.sort((left, right) => right.start - left.start)) output = `${output.slice(0, replacement.start)}${replacement.text}${output.slice(replacement.end)}`
+    for (const replacement of replacements.sort((left, right) => right.start - left.start))
+        output = `${output.slice(0, replacement.start)}${replacement.text}${output.slice(replacement.end)}`
 
     return output
 }
@@ -2925,6 +2948,48 @@ const canonicalizeConditionStatements = (
 
         replacements.push({
             start: nodeRange[0],
+            end: bodyRange[0],
+            text: replacement,
+        })
+    }
+
+    // A loop whose body is a single statement gets the same shape as a brace-less `if`:
+    // the body moves to its own line, one step in. Only whitespace sits between the head
+    // and the body, so the head ends at the `)` immediately before it.
+    const addLoopBodyBreak = (
+        node: AstNode,
+        body: AstNode | null | undefined,
+    ): void => {
+        const nodeRange = getNodeRange(node)
+        const bodyRange = getNodeRange(body)
+
+        if (
+            !nodeRange
+            || !body
+            || !bodyRange
+            || body.type === 'BlockStatement'
+            || hasCommentWithinRange(comments, [nodeRange[0], bodyRange[0]])
+        )
+            return
+
+        let headEnd = bodyRange[0]
+
+        while (
+            headEnd > nodeRange[0]
+            && isWhitespaceCharacter(source[headEnd - 1])
+        )
+            headEnd--
+
+        if (source[headEnd - 1] !== ')')
+            return
+
+        const replacement = `\n${getLineIndentation(source, nodeRange[0])}    `
+
+        if (source.slice(headEnd, bodyRange[0]) === replacement)
+            return
+
+        replacements.push({
+            start: headEnd,
             end: bodyRange[0],
             text: replacement,
         })
@@ -3083,8 +3148,14 @@ const canonicalizeConditionStatements = (
                         text: replacement,
                     })
                 }
-            }
-        } else if (node.type === 'ConditionalExpression') {
+            } else
+                addLoopBodyBreak(node, body)
+        } else if (
+            node.type === 'ForOfStatement'
+            || node.type === 'ForInStatement'
+        )
+            addLoopBodyBreak(node, node.body as AstNode | undefined)
+        else if (node.type === 'ConditionalExpression') {
             const test = node.test as AstNode | undefined
             const consequent = node.consequent as AstNode | undefined
             const alternate = node.alternate as AstNode | undefined
@@ -3138,8 +3209,9 @@ const canonicalizeConditionStatements = (
                 continue
 
             if (Array.isArray(value)) {
-                for (const child of value) if (isAstNode(child))
-                    visit(child)
+                for (const child of value)
+                    if (isAstNode(child))
+                        visit(child)
             } else if (isAstNode(value))
                 visit(value)
         }
@@ -3159,10 +3231,8 @@ const canonicalizeConditionStatements = (
 
     let output = source
 
-    for (const replacement of nonOverlappingReplacements.sort((left, right) => right.start - left.start)) output = `${output.slice(
-        0,
-        replacement.start,
-    )}${replacement.text}${output.slice(replacement.end)}`
+    for (const replacement of nonOverlappingReplacements.sort((left, right) => right.start - left.start))
+        output = `${output.slice(0, replacement.start)}${replacement.text}${output.slice(replacement.end)}`
 
     return output
 }
@@ -3358,8 +3428,9 @@ const canonicalizeContainerIndentationOnce = (
                 continue
 
             if (Array.isArray(value)) {
-                for (const child of value) if (isAstNode(child))
-                    visit(child)
+                for (const child of value)
+                    if (isAstNode(child))
+                        visit(child)
             } else if (isAstNode(value))
                 visit(value)
         }
@@ -3368,10 +3439,8 @@ const canonicalizeContainerIndentationOnce = (
     visit(parseResult.program as AstNode)
     let output = source
 
-    for (const replacement of [...replacementsByRange.values()].sort((left, right) => right.start - left.start)) output = `${output.slice(
-        0,
-        replacement.start,
-    )}${replacement.text}${output.slice(replacement.end)}`
+    for (const replacement of [...replacementsByRange.values()].sort((left, right) => right.start - left.start))
+        output = `${output.slice(0, replacement.start)}${replacement.text}${output.slice(replacement.end)}`
 
     return output
 }
@@ -3539,7 +3608,8 @@ const {
 } = await collectFormattingFiles(inputPaths)
 
 if (prohibitedFiles.length > 0) {
-    for (const file of prohibitedFiles) err(`${file}: JSX source files are prohibited; use a .ts module and the repository DOM APIs`)
+    for (const file of prohibitedFiles)
+        err(`${file}: JSX source files are prohibited; use a .ts module and the repository DOM APIs`)
 
     process.exit(1)
 }

--- a/services/web-ui/src/components/aiModelControls/aiModelControls.ts
+++ b/services/web-ui/src/components/aiModelControls/aiModelControls.ts
@@ -1295,7 +1295,8 @@ class MediaGenerationConfigMatrixView implements MediaGenerationConfigMatrixView
             )
         }
 
-        for (const dropdown of this.mountedModelDropdowns) dropdown.update()
+        for (const dropdown of this.mountedModelDropdowns)
+            dropdown.update()
     }
 
     private getSelectionForGroup(

--- a/services/web-ui/src/components/executionTrace/executionTraceDetails.ts
+++ b/services/web-ui/src/components/executionTrace/executionTraceDetails.ts
@@ -421,7 +421,8 @@ class ExecutionTraceDetail implements ExecutionTraceDetailInstance {
     }
 
     destroy(): void {
-        for (const instance of this.previewInstances) instance.destroy()
+        for (const instance of this.previewInstances)
+            instance.destroy()
 
         this.previewInstances.length = 0
         this.element.remove()

--- a/services/web-ui/src/components/navigationSidePanel/navigationSidePanel.ts
+++ b/services/web-ui/src/components/navigationSidePanel/navigationSidePanel.ts
@@ -253,7 +253,8 @@ class NavigationSidePanel implements NavigationSidePanelInstance {
         const workspaces = workspacesStore.getData()
         const currentWorkspaceId = routerStore.getData('currentRoute')?.routeParams?.workspaceId
 
-        for (const dropdown of this.workspaceDropdowns.values()) dropdown.destroy()
+        for (const dropdown of this.workspaceDropdowns.values())
+            dropdown.destroy()
 
         this.workspaceDropdowns.clear()
 
@@ -425,9 +426,11 @@ class NavigationSidePanel implements NavigationSidePanelInstance {
     destroy = (): void => {
         this.importFileInput.removeEventListener('change', this.handleImportFileSelected)
 
-        for (const unsubscribe of this.unsubscribers) unsubscribe()
+        for (const unsubscribe of this.unsubscribers)
+            unsubscribe()
 
-        for (const dropdown of this.workspaceDropdowns.values()) dropdown.destroy()
+        for (const dropdown of this.workspaceDropdowns.values())
+            dropdown.destroy()
 
         this.workspaceDropdowns.clear()
         this.sidePanel.destroy()

--- a/services/web-ui/src/components/proseMirror/components/keyMap.ts
+++ b/services/web-ui/src/components/proseMirror/components/keyMap.ts
@@ -182,10 +182,11 @@ export const buildKeymap = (
     const heading = schema.nodes.heading
 
     if (heading) {
-        for (let level = 1; level <= 6; level += 1) bind(
-            `Shift-Ctrl-${level}`,
-            setBlockType(heading, { level }),
-        )
+        for (let level = 1; level <= 6; level += 1)
+            bind(
+                `Shift-Ctrl-${level}`,
+                setBlockType(heading, { level }),
+            )
     }
 
     const horizontalRule = schema.nodes.horizontal_rule

--- a/services/web-ui/src/components/proseMirror/plugins/aiChatThreadPlugin/aiUserMessageNode.ts
+++ b/services/web-ui/src/components/proseMirror/plugins/aiChatThreadPlugin/aiUserMessageNode.ts
@@ -66,7 +66,8 @@ export const aiUserMessageNodeView = (
     let tileInstances: ContextPreviewTileInstance[] = []
 
     const destroyReferencePreviews = (): void => {
-        for (const tile of tileInstances) tile.destroy()
+        for (const tile of tileInstances)
+            tile.destroy()
 
         tileInstances = []
         shell.referencePreviewsEl.replaceChildren()

--- a/services/web-ui/src/components/proseMirror/plugins/aiChatThreadPlugin/capabilityChatRunProgress.ts
+++ b/services/web-ui/src/components/proseMirror/plugins/aiChatThreadPlugin/capabilityChatRunProgress.ts
@@ -61,7 +61,8 @@ export class CapabilityChatRunProgressController {
     }
 
     destroy(): void {
-        for (const progress of this.progressByRunId.values()) progress.destroy()
+        for (const progress of this.progressByRunId.values())
+            progress.destroy()
 
         this.progressByRunId.clear()
     }

--- a/services/web-ui/src/installed-capabilities.ts
+++ b/services/web-ui/src/installed-capabilities.ts
@@ -129,7 +129,8 @@ export const createInstalledCapabilityControls = (host: CapabilityControlsHost):
             }
         },
         destroy: () => {
-            for (const module of installedModules) unmount(module)
+            for (const module of installedModules)
+                unmount(module)
         },
     }
 }

--- a/services/web-ui/src/services/asset-service.ts
+++ b/services/web-ui/src/services/asset-service.ts
@@ -167,7 +167,8 @@ export class AssetService {
         const missingAssetIds = [...new Set(assetIds)].filter(assetId => assetId && !assetsStore.get(assetId))
         const loadedAssets = await this.loadAssetsById(missingAssetIds)
 
-        for (const asset of loadedAssets) assetsStore.upsert(asset)
+        for (const asset of loadedAssets)
+            assetsStore.upsert(asset)
 
         return loadedAssets
     }

--- a/services/web-ui/src/services/prosemirror-authority-service.ts
+++ b/services/web-ui/src/services/prosemirror-authority-service.ts
@@ -420,7 +420,8 @@ export class ProseMirrorAuthorityService {
                         this.applySnapshot(snapshot.doc, snapshot.version)
                 }
 
-                for (const event of result.events ?? []) this.handleEvent(event)
+                for (const event of result.events ?? [])
+                    this.handleEvent(event)
 
                 this.localStreamSeq = Math.max(this.localStreamSeq, result.currentStreamSeq ?? 0)
                 hasMore = result.hasMore === true
@@ -658,7 +659,8 @@ export class ProseMirrorAuthorityService {
         } finally {
             this.submitting = false
 
-            for (const resolve of this.submissionWaiters.splice(0)) resolve()
+            for (const resolve of this.submissionWaiters.splice(0))
+                resolve()
 
             if (this.pendingLocalSteps.length > 0)
                 this.scheduleSubmit()


### PR DESCRIPTION
A loop whose body is a single statement kept that body on the header line:

```ts
for (const module of installedModules) unmount(module)
```

It now gets the same shape as a brace-less `if` — body on its own line, one step in:

```ts
for (const module of installedModules)
    unmount(module)
```

`while` already behaved this way. `for...of` and `for...in` had no handling at all in `canonicalizeConditionStatements`, and a classic `for` was only rewritten when its test carried several conditions, so every other loop kept its body inline.

The rule reuses the existing machinery: it skips a `BlockStatement` body, skips anything with a comment between the head and the body, and locates the end of the head at the `)` immediately before the body, since only whitespace separates them. Anchoring on the head's own indentation keeps a second run a no-op.

## Scope

This commit carries the reformat the rule produces — 104 files — so `main` still validates clean once it lands. Without it the `Formatting and linting` jobs would go red on every file holding a brace-less loop.

Loops inside `.test.ts` files are untouched. `collectFormattingFiles` skips test files via `isTestFile`, which is existing policy in this runner, not something this change alters. If you want test files formatted too, that's a separate decision and I'd rather make it deliberately.

## Verification

`all validate` reports 0 errors, and the rule is idempotent across repeated runs on a fixture covering `for...of`, `for...in`, classic `for`, `while`, an already-braced body and an already-broken body. Tests: api 868 with 7 skipped, web-ui 1076, nex 72, shared 969 plus every package suite. Quality runner self-test passes.

Relates to #366